### PR TITLE
fix(release): correct path for docs commit and update refs to v0.2.0

### DIFF
--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -22,7 +22,7 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 
 - name: Read project.yml configuration
   id: config
-  uses: cuioss/cuioss-organization/.github/actions/read-project-config@main
+  uses: cuioss/cuioss-organization/.github/actions/read-project-config@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
 
 - name: Use configuration
   run: |
@@ -34,7 +34,7 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 
 [source,yaml]
 ----
-- uses: cuioss/cuioss-organization/.github/actions/read-project-config@main
+- uses: cuioss/cuioss-organization/.github/actions/read-project-config@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
   id: config
   with:
     config-path: 'custom/path/project.yml'
@@ -214,7 +214,7 @@ custom:
 
 [source,yaml]
 ----
-- uses: cuioss/cuioss-organization/.github/actions/read-project-config@main
+- uses: cuioss/cuioss-organization/.github/actions/read-project-config@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
   id: config
 
 - name: Run E2E tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Commit docs update
         run: |
-          git add .github/workflows/examples/ .github/actions/*/README.md .github/actions/*/README.adoc docs/Workflows.adoc README.adoc || true
+          git add docs/workflow-examples/ .github/actions/*/README.md .github/actions/*/README.adoc docs/Workflows.adoc README.adoc || true
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/README.adoc
+++ b/README.adoc
@@ -74,7 +74,7 @@ Use centralized workflows instead of copy-pasting:
 # In your repo's .github/workflows/release.yml
 jobs:
   release:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit
 ----
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -120,7 +120,7 @@ concurrency:
 
 jobs:
   build:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit
 ----
 
@@ -201,7 +201,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit
 ----
 
@@ -272,7 +272,7 @@ on:
 
 jobs:
   analysis:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit
 ----
 
@@ -300,7 +300,7 @@ on: [pull_request]
 
 jobs:
   dependency-review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit
 ----
 
@@ -347,7 +347,7 @@ concurrency:
 
 jobs:
   verify:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
 ----
 
 === Inputs

--- a/docs/workflow-examples/dependency-review-caller.yml
+++ b/docs/workflow-examples/dependency-review-caller.yml
@@ -5,5 +5,5 @@ on: [pull_request]
 
 jobs:
   dependency-review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     with:
       # Override project.yml settings with explicit inputs
       java-versions: '["21","25"]'

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   build:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit

--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -15,5 +15,5 @@ permissions:
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   verify:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     # Optional inputs (all have sensible defaults):
     # with:
     #   python-version: '3.12'           # Leave empty to let uv manage from pyproject.toml

--- a/docs/workflow-examples/scorecards-caller.yml
+++ b/docs/workflow-examples/scorecards-caller.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   analysis:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@ab9c1504e30dcc5928d86d9e0147bc1ceb35383c # v0.1.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0
     secrets: inherit


### PR DESCRIPTION
## Summary

Fixes a bug in the release workflow and updates documentation to v0.2.0.

## Bug Fix

The release workflow was using a non-existent path in the `git add` command:
- **Wrong**: `.github/workflows/examples/`
- **Correct**: `docs/workflow-examples/`

This caused the documentation updates to not be committed during the v0.2.0 release.

## Documentation Updates

Updated all workflow references from v0.1.0 to v0.2.0:
- SHA: `288f393bf5407c87ffd95c128cdf694761941308`
- Version comment: `# v0.2.0`

### Files updated:
- `docs/workflow-examples/*.yml` (6 files)
- `docs/Workflows.adoc`
- `README.adoc`
- `.github/actions/read-project-config/README.adoc`

🤖 Generated with [Claude Code](https://claude.ai/code)