### PR TITLE
fix(script): skip release.yml in update-workflow-references

### DIFF
--- a/workflow-scripts/update-workflow-references.py
+++ b/workflow-scripts/update-workflow-references.py
@@ -82,6 +82,9 @@ def update_workflow_references(
             # In normal mode, skip reusable workflows (they use version tags)
             if not internal_only and yml_file.name.startswith('reusable-'):
                 continue
+            # Always skip release.yml - it contains template placeholders like ${{ steps.sha.outputs.sha }}
+            if yml_file.name == 'release.yml':
+                continue
 
             content = yml_file.read_text()
             new_content = apply_patterns(content)


### PR DESCRIPTION
## Summary

Fixes a bug where `update-workflow-references.py` incorrectly modified `release.yml`.

## Problem

The script was replacing template placeholders in `release.yml`:
```yaml
# Before (template - should not change)
uses: ...@${{ steps.sha.outputs.sha }} # ${{ steps.tag.outputs.version }}

# After (incorrectly modified)
uses: ...@288f393bf5407c87ffd95c128cdf694761941308 # v0.2.0 steps.sha.outputs.sha }} # ${{ steps.tag.outputs.version }}
```

## Solution

Skip `release.yml` in the workflow processing loop since it contains GitHub Actions expression placeholders that should remain as templates.

## Test Coverage

Added `TestReleaseWorkflowSkipping::test_skips_release_yml_in_normal_mode` to verify:
- `release.yml` with template placeholders is not modified
- Regular workflows are still updated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)