### PR TITLE
feat(branch-protection): enable strict status checks policy

### DIFF
--- a/branch-protection/README.adoc
+++ b/branch-protection/README.adoc
@@ -95,7 +95,7 @@ The `config.json` defines default settings:
         "required_review_thread_resolution": false
       },
       "require_status_checks": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_checks": []
       }
@@ -118,6 +118,9 @@ When applied, the ruleset enforces:
 * **Force push protection**: Cannot force push to main
 * **Pull request requirement**: Changes must go through PRs (review count configurable)
 * **Status checks**: Required checks must pass before merge (configurable per repo)
+* **Up-to-date branches**: PR branches must be up-to-date with main before merging (`strict_required_status_checks_policy: true`)
+
+NOTE: The "up-to-date branches" requirement improves OpenSSF Scorecard score by ensuring PRs are rebased before merge, preventing integration issues.
 
 == Dry Run
 

--- a/branch-protection/config.json
+++ b/branch-protection/config.json
@@ -20,7 +20,7 @@
         "required_review_thread_resolution": false
       },
       "require_status_checks": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_checks": []
       },


### PR DESCRIPTION
## Summary
Enable `strict_required_status_checks_policy: true` to require PR branches to be up-to-date with main before merging.

## Why
This improves OpenSSF Scorecard Branch-Protection score by satisfying the "up-to-date branches" requirement (Tier 2).

## Changes
- `branch-protection/config.json`: Set `strict_required_status_checks_policy: true`
- `branch-protection/README.adoc`: Document the up-to-date branches requirement

## Applied
Already applied to cuioss-organization repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)