### PR TITLE
fix(workflows): add dependabot/* to push triggers

### DIFF
--- a/.github/workflows/python-verify.yml
+++ b/.github/workflows/python-verify.yml
@@ -2,7 +2,7 @@ name: Python Verify
 
 on:
   push:
-    branches: [main, "feature/*"]
+    branches: [main, "feature/*", "dependabot/*"]
   pull_request:
     branches: [main]
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -15,7 +15,7 @@ All cuioss caller workflows use a consistent trigger pattern:
 ----
 on:
   push:
-    branches: [main, "feature/*"]
+    branches: [main, "feature/*", "dependabot/*"]
   pull_request:
     branches: [main]
 
@@ -27,7 +27,7 @@ jobs:
 
 === Why This Pattern?
 
-* **`push` to `main` and `feature/*`**: Ensures all commits are verified, including early pushes to feature branches before a PR is opened.
+* **`push` to `main`, `feature/*`, and `dependabot/*`**: Ensures all commits are verified, including early pushes to feature branches and dependabot updates before a PR is opened.
 * **`pull_request` to `main`**: Verifies all pull requests targeting the main branch, especially important for fork PRs.
 
 === Avoiding Duplicate Runs

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -3,7 +3,7 @@ name: Maven Build
 
 on:
   push:
-    branches: [main, "feature/*"]
+    branches: [main, "feature/*", "dependabot/*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -4,7 +4,7 @@ name: Maven Build
 
 on:
   push:
-    branches: [main, "feature/*"]
+    branches: [main, "feature/*", "dependabot/*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -5,7 +5,7 @@ name: Python Verify
 
 on:
   push:
-    branches: [main, "feature/*"]
+    branches: [main, "feature/*", "dependabot/*"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Adds `dependabot/*` to push triggers for workflow files
- Fixes issue where dependabot PRs don't trigger the verify workflow

## Problem
Dependabot branches (`dependabot/github_actions/...`) don't match the `feature/*` pattern. Combined with our duplicate-prevention condition that skips PR events for internal branches, this means dependabot PRs never trigger the verify workflow.

## Solution
Add `dependabot/*` to the push trigger branches. The push event will now trigger for dependabot branches, and the PR event correctly skips (since it's an internal branch).

## Files Changed
- `.github/workflows/python-verify.yml`
- `docs/Workflows.adoc`
- `docs/workflow-examples/maven-build-caller.yml`
- `docs/workflow-examples/maven-build-caller-custom.yml`
- `docs/workflow-examples/pyprojectx-verify-caller.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)