### PR TITLE
feat(workflows): add fix/* to push trigger branches

### DIFF
--- a/.github/workflows/python-verify.yml
+++ b/.github/workflows/python-verify.yml
@@ -2,7 +2,7 @@ name: Python Verify
 
 on:
   push:
-    branches: [main, "feature/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "dependabot/**"]
   pull_request:
     branches: [main]
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -15,7 +15,7 @@ All cuioss caller workflows use a consistent trigger pattern:
 ----
 on:
   push:
-    branches: [main, "feature/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "dependabot/**"]
   pull_request:
     branches: [main]
 
@@ -27,7 +27,7 @@ jobs:
 
 === Why This Pattern?
 
-* **`push` to `main`, `feature/*`, and `dependabot/**`**: Ensures all commits are verified, including early pushes to feature branches and dependabot updates before a PR is opened.
+* **`push` to `main`, `feature/*`, `fix/*`, and `dependabot/**`**: Ensures all commits are verified, including early pushes to feature/fix branches and dependabot updates before a PR is opened.
 * **`pull_request` to `main`**: Verifies all pull requests targeting the main branch, especially important for fork PRs.
 
 === Avoiding Duplicate Runs

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -3,7 +3,7 @@ name: Maven Build
 
 on:
   push:
-    branches: [main, "feature/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "dependabot/**"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -4,7 +4,7 @@ name: Maven Build
 
 on:
   push:
-    branches: [main, "feature/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "dependabot/**"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -5,7 +5,7 @@ name: Python Verify
 
 on:
   push:
-    branches: [main, "feature/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "dependabot/**"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Adds `fix/*` to workflow push trigger branches

## Problem
Branches using `fix/` prefix don't trigger the verify workflow, causing PRs from those branches to be stuck without the required `verify / verify` check.

## Solution
Add `fix/*` pattern alongside `feature/*` to ensure all common branch naming patterns trigger CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)