### PR TITLE
fix: add top-level permissions to maven build caller templates

### DIFF
--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -124,6 +124,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Run on push, OR on pull_request only if from a fork
@@ -376,6 +379,9 @@ on:
     branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   verify:

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Run on push events, OR on pull_request only if from a fork

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Run on push events, OR on pull_request only if from a fork


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `maven-build-caller.yml` and `maven-build-caller-custom.yml`
- Add matching permissions block to Maven Build and Pyprojectx examples in `Workflows.adoc`
- Resolves OpenSSF Scorecard `TokenPermissionsID` alert in consumer repos

## Test plan
- [ ] `verify / verify` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)