### PR TITLE
fix: simplify update-workflow-references with SHA-based global replacement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Commit reference updates
         run: |
-          git add .github/workflows/reusable-*.yml docs/workflow-examples/ .github/actions/*/README.md .github/actions/*/README.adoc docs/*.adoc README.adoc || true
+          git add -A || true
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
## Summary
Since all files share the same SHA after a release, the script can discover the old SHA and do a simple global replacement instead of scanning specific directories with complex regex.

## What changed

**Before**: 2 regex patterns + 7 directory-scanning blocks. Every new file location required a code change (root cause of the `project-yml-schema.adoc` miss).

**After**: 
- **Normal mode**: discover old SHA from files → replace globally via `git ls-files`
- **Internal-only mode**: unchanged (still regex for `reusable-*.yml`)
- **Fallback**: regex-based replacement when no old SHA exists (first-time setup)

Also simplifies `release.yml` git add from a long glob list to `git add -A`.

## Test plan
- [x] All 94 tests pass (`./pw verify`)
- [x] mypy clean, ruff clean
- [ ] Verify on next release that SHA propagates to all files

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>