### PR TITLE
fix: remove secret expressions from release body template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,7 @@ jobs:
             jobs:
               build:
                 uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@${{ steps.sha.outputs.sha }} # ${{ steps.tag.outputs.version }}
-                secrets:
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-                  OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
-                  OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
-                  GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-                  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+                secrets: inherit
             ```
 
       - name: Update consumer repos


### PR DESCRIPTION
## Summary
- **SECURITY FIX**: The release workflow body used `${{ secrets.* }}` expressions in the example YAML section. GitHub Actions expanded these to actual secret values, exposing them in the public release notes.
- Replaced explicit secret references with `secrets: inherit` (matching v0.2.0 and v0.1.0 releases)
- Release v0.2.1 has been deleted and will need to be re-created after this fix

## Test plan
- [ ] CI passes
- [ ] Verify the release body template no longer contains `${{ secrets.* }}` expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)