### PR TITLE
chore: add consumers tracking to setup-consumer-repo workflow

### DIFF
--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -73,7 +73,14 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
     - Monitor: `gh run list --repo cuioss/{repo-name} --branch main --limit 3`
     - Report final status
 
-12. **Scorecard Analysis**
+12. **Update Consumers List**
+    - In the cuioss-organization repo, update `.github/project.yml`:
+      - Check if `{repo-name}` is already in the `consumers` list
+      - If not present, add it to the `consumers` list
+      - Commit: `git add .github/project.yml && git commit -m "chore: add {repo-name} to consumers list"`
+      - Push: `git push`
+
+13. **Scorecard Analysis**
     - Wait for the Scorecard workflow to complete on main (triggered by the merge push)
     - If scorecards didn't trigger automatically, note that it runs on schedule or `push` to main
     - Fetch all open code-scanning alerts:
@@ -100,7 +107,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
     - If any alerts are classified as **Fixed**, create a follow-up fix branch, apply changes, create PR, wait for CI, and merge
     - Report the final table to the user
 
-13. **SonarCloud Analysis**
+14. **SonarCloud Analysis**
     - Determine the SonarCloud project key (typically `cuioss_{repo-name}` with hyphens preserved, e.g., `cuioss_cui-java-module-template`)
     - **A. Clean up stale SARIF analyses**:
       - Fetch all code-scanning analyses for the SonarCloud tool:

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -7,4 +7,5 @@ release:
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)
-consumers: []
+consumers:
+  - cui-java-module-template


### PR DESCRIPTION
## Summary
- Add `cui-java-module-template` to `project.yml` consumers list (previously empty)
- Add step 12 ("Update Consumers List") to `setup-consumer-repo` command to automatically track which repos have been set up

## Changes
- `.github/project.yml`: Populated `consumers` list with `cui-java-module-template`
- `.claude/commands/setup-consumer-repo.md`: Added step 12 to update consumers list in the organization repo after successful merge, renumbered subsequent steps

## Test plan
- [ ] Verify `project.yml` YAML is valid
- [ ] Verify step numbering in `setup-consumer-repo.md` is correct and sequential

🤖 Generated with [Claude Code](https://claude.com/claude-code)