### PR TITLE
fix: restore python label for this repo's dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+      - "python"


### PR DESCRIPTION
## Summary
- Restore `python` label in `dependabot.yml` pip ecosystem entry for this repo
- The `python` label is specific to `cuioss-organization` (which has Python scripts), not a default for consumer repos

## Test plan
- [ ] Verify no Dependabot warnings about missing labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)