### PR TITLE
chore: add cui-java-tools to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -9,3 +9,4 @@ release:
 # Repositories that consume these workflows (added automatically by /update-github-actions)
 consumers:
   - cui-java-module-template
+  - cui-java-tools


### PR DESCRIPTION
## Summary
- Add cui-java-tools to the consumers list in project.yml after successful workflow migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)