### PR TITLE
fix: use release-bot token for pages deploy and fix secrets in if-condition

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -32,8 +32,6 @@ on:
         required: true
       GPG_PASSPHRASE:
         required: true
-      PAGES_DEPLOY_TOKEN:
-        required: false
 
 permissions:
   contents: read
@@ -56,6 +54,8 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }},cuioss.github.io
+          owner: cuioss
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -107,14 +107,14 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Deploy Maven Site
-        if: ${{ (steps.config.outputs.deploy-site != 'false' && inputs.deploy-site) && secrets.PAGES_DEPLOY_TOKEN != '' }}
+        if: ${{ steps.config.outputs.deploy-site != 'false' && inputs.deploy-site }}
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           folder: target/site
           repository-name: cuioss/cuioss.github.io
           target-folder: ${{ steps.config.outputs.pages-reference }}
           branch: main
-          token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Push changes
         uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0

--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -23,4 +23,3 @@ jobs:
       OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      PAGES_DEPLOY_TOKEN: ${{ secrets.PAGES_DEPLOY_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix workflow parse error: `secrets` context cannot be used in step `if` conditions
- Replace `PAGES_DEPLOY_TOKEN` with release-bot app token for Maven site deployment
- Scope release-bot token to both source repo and `cuioss.github.io`

## Changes
- `reusable-maven-release.yml`: Remove `PAGES_DEPLOY_TOKEN` secret, use `release-token` for pages deploy, fix `if` condition
- `maven-release-caller.yml`: Remove `PAGES_DEPLOY_TOKEN` from caller template

## Root Cause
The `if` condition `secrets.PAGES_DEPLOY_TOKEN != ''` on line 110 caused GitHub Actions to fail with "Unrecognized named-value: 'secrets'" — the `secrets` context is not available in `if` expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)