### PR TITLE
fix: set contents: write in release caller template

### DIFF
--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- The reusable release workflow needs `contents: write` permission
- The caller template had `contents: read` which prevented the reusable workflow from starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)