### PR TITLE
chore: prepare release 0.2.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.1
+  current-version: 0.2.2
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary
- Bump current-version from 0.2.1 to 0.2.2

## Changes
- Updated workflow references and caller templates will be pinned to the new release SHA
- Consumer repos (cui-java-module-template, cui-java-tools) will receive auto-PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)