### PR TITLE
fix: consumer repo push authentication in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: cuioss
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/workflow-scripts/update-consumer-repo.py
+++ b/workflow-scripts/update-consumer-repo.py
@@ -60,6 +60,14 @@ def update_consumer_repo(
             print("::endgroup::")
             return False
 
+        # Configure git credential helper to use GH_TOKEN for push operations
+        # gh repo clone sets up HTTPS remote but git push needs explicit auth
+        run_git(
+            ["config", "credential.helper", "!gh auth git-credential"],
+            cwd=repo_dir,
+            check=False,
+        )
+
         # Check for workflows directory
         if not (repo_dir / ".github" / "workflows").exists():
             print(f"::warning::No .github/workflows directory in {repo}, skipping")


### PR DESCRIPTION
## Summary
- Configure git credential helper (`gh auth git-credential`) after cloning consumer repos
- Add `owner: cuioss` to release token for cross-repo push/PR access
- Fixes `fatal: could not read Username` error during consumer repo updates

## Root Cause
`gh repo clone` sets up HTTPS remotes but plain `git push` has no access to the GH_TOKEN.
The release token also lacked cross-repo scope (no `owner` specified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)