### PR TITLE
chore: prepare release 0.2.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.2
+  current-version: 0.2.3
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary
- Bump current-version from 0.2.2 to 0.2.3
- Includes consumer repo push auth fix from PR #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)