### PR TITLE
fix: add --head flag to consumer repo PR creation

### DIFF
--- a/workflow-scripts/update-consumer-repo.py
+++ b/workflow-scripts/update-consumer-repo.py
@@ -129,8 +129,9 @@ def update_consumer_repo(
             print(f"::warning::Failed to push: {result.stderr}")
             print("::endgroup::")
             return False
+        print("Push successful")
 
-        # Create PR
+        # Create PR (--head is required for shallow clones in temp directories)
         print("Creating pull request...")
         pr_body = (
             f"Updates workflow references to SHA `{sha}` (v{version})\n\n"
@@ -142,6 +143,8 @@ def update_consumer_repo(
                 "create",
                 "--repo",
                 full_repo,
+                "--head",
+                branch,
                 "--title",
                 f"chore: update cuioss-organization workflows to v{version}",
                 "--body",


### PR DESCRIPTION
## Summary
- Add `--head` flag to `gh pr create` in update-consumer-repo.py
- Add push success logging for debugging
- Fixes "you must first push the current branch to a remote" error

## Root Cause
`gh pr create` in a shallow clone temp directory can't auto-detect the head branch.
The `--head` flag explicitly specifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)