### PR TITLE
feat: auto-merge consumer repo workflow update PRs and release summary

### DIFF
--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -199,6 +199,18 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
 /setup-consumer-repo cui-java-module-template  # Full setup for template repo
 ```
 
+## GitHub Automation Configuration
+
+Consumer repos can configure auto-merge behavior for workflow update PRs in their `.github/project.yml`:
+
+```yaml
+github-automation:
+  auto-merge-build-versions: true   # Auto-merge when CI passes (default: true)
+  auto-merge-build-timeout: 240     # Seconds to wait for CI (default: 240, range: 30-600)
+```
+
+When auto-merge is enabled, the release workflow will poll CI checks and automatically squash-merge the PR once all checks pass. If checks fail or timeout, the PR is left open for manual review.
+
 ## Prerequisites
 
 - `gh` CLI authenticated with admin access

--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -148,6 +148,10 @@ sonar:
 pages:
   reference: {repo-name}
   deploy-at-release: true
+
+github-automation:
+  auto-merge-build-versions: true
+  auto-merge-build-timeout: 240
 ```
 
 ## Custom Fields Extension

--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -154,6 +154,20 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 | Verification command to run
 |===
 
+=== GitHub Automation Section
+
+|===
+| Output | Default | Description
+
+| `auto-merge-build-versions`
+| `'true'`
+| Auto-merge consumer repo workflow update PRs when CI passes
+
+| `auto-merge-build-timeout`
+| `'240'`
+| Timeout in seconds for waiting on CI checks before auto-merge
+|===
+
 === Other
 
 |===

--- a/.github/actions/read-project-config/action.yml
+++ b/.github/actions/read-project-config/action.yml
@@ -77,6 +77,14 @@ outputs:
     description: 'Verification command to run'
     value: ${{ steps.config.outputs.pyprojectx-verify-command }}
 
+  # GitHub Automation Section
+  auto-merge-build-versions:
+    description: 'Auto-merge consumer repo workflow update PRs when CI passes'
+    value: ${{ steps.config.outputs.auto-merge-build-versions }}
+  auto-merge-build-timeout:
+    description: 'Timeout in seconds for waiting on CI checks before auto-merge'
+    value: ${{ steps.config.outputs.auto-merge-build-timeout }}
+
   # Consumers
   consumers:
     description: 'Space-separated list of consumer repositories'

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -54,6 +54,9 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "uv.lock", None),
     (["pyprojectx", "upload-artifacts-on-failure"], "pyprojectx-upload-artifacts-on-failure", False, None),
     (["pyprojectx", "verify-command"], "pyprojectx-verify-command", "./pw verify", None),
+    # github-automation section
+    (["github-automation", "auto-merge-build-versions"], "auto-merge-build-versions", True, None),
+    (["github-automation", "auto-merge-build-timeout"], "auto-merge-build-timeout", 240, None),
     # consumers list (special case: transform list to space-separated string)
     (["consumers"], "consumers", [], lambda x: " ".join(x) if isinstance(x, list) else ""),
 ]
@@ -181,6 +184,7 @@ def print_config_summary(outputs: dict[str, str], config_found: bool, config_pat
         "Pages": ["pages-reference", "deploy-site"],
         "Pyprojectx": ["pyprojectx-python-version", "pyprojectx-cache-dependency-glob",
                        "pyprojectx-upload-artifacts-on-failure", "pyprojectx-verify-command"],
+        "GitHub Automation": ["auto-merge-build-versions", "auto-merge-build-timeout"],
         "Other": ["consumers"],
     }
 

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -145,6 +145,25 @@
       },
       "additionalProperties": false
     },
+    "github-automation": {
+      "type": "object",
+      "description": "GitHub automation settings for consumer repo workflow updates",
+      "properties": {
+        "auto-merge-build-versions": {
+          "type": "boolean",
+          "description": "Auto-merge workflow update PRs when CI checks pass",
+          "default": true
+        },
+        "auto-merge-build-timeout": {
+          "type": "integer",
+          "description": "Timeout in seconds for waiting on CI checks before auto-merge",
+          "default": 240,
+          "minimum": 30,
+          "maximum": 600
+        }
+      },
+      "additionalProperties": false
+    },
     "consumers": {
       "type": "array",
       "description": "List of repositories that consume this repository (for automated updates)",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,9 +110,52 @@ jobs:
           SHA="${{ steps.sha.outputs.sha }}"
           CONSUMERS="${{ steps.metadata.outputs.consumers }}"
 
+          # Collect results for summary
+          RESULTS_FILE=$(mktemp)
+          echo "[]" > "$RESULTS_FILE"
+
           for REPO in $CONSUMERS; do
-            python3 "$GITHUB_WORKSPACE/workflow-scripts/update-consumer-repo.py" \
+            OUTPUT=$(python3 "$GITHUB_WORKSPACE/workflow-scripts/update-consumer-repo.py" \
               --repo "$REPO" \
               --version "$VERSION" \
-              --sha "$SHA" || true
+              --sha "$SHA" 2>&1) || true
+            echo "$OUTPUT"
+
+            # Extract RESULT JSON line
+            RESULT_LINE=$(echo "$OUTPUT" | grep '^RESULT:' | sed 's/^RESULT://')
+            if [ -n "$RESULT_LINE" ]; then
+              # Append repo name and result to results file
+              jq --arg repo "$REPO" --argjson result "$RESULT_LINE" \
+                '. += [{"repo": $repo} + $result]' "$RESULTS_FILE" > "${RESULTS_FILE}.tmp" \
+                && mv "${RESULTS_FILE}.tmp" "$RESULTS_FILE"
+            fi
           done
+
+          # Build release summary
+          {
+            echo "## Release v${VERSION} Summary"
+            echo ""
+            echo "**Version:** v${VERSION}"
+            echo "**SHA:** \`${SHA}\`"
+            echo ""
+
+            if [ -n "$CONSUMERS" ]; then
+              echo "### Consumer Repository Updates"
+              echo ""
+              echo "| Repository | Status | PR |"
+              echo "|---|---|---|"
+
+              jq -r '.[] |
+                if .status == "pr_created_and_merged" then
+                  "| " + .repo + " | :white_check_mark: Merged | [PR](" + (.pr_url // "-") + ") |"
+                elif .status == "pr_created" then
+                  "| " + .repo + " | :arrow_right: PR Created | [PR](" + (.pr_url // "-") + ") |"
+                elif .status == "no_changes" then
+                  "| " + .repo + " | :heavy_minus_sign: No Changes | - |"
+                else
+                  "| " + .repo + " | :x: Error | " + (.error // "unknown") + " |"
+                end' "$RESULTS_FILE"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          rm -f "$RESULTS_FILE"

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -112,6 +112,15 @@ jobs:
 |`pages.deploy-at-release` |boolean |`true` |Deploy Maven site to GitHub Pages during release
 |===
 
+==== GitHub Automation Section
+
+|===
+|Field |Type |Default |Description
+
+|`github-automation.auto-merge-build-versions` |boolean |`true` |Auto-merge workflow update PRs when CI checks pass
+|`github-automation.auto-merge-build-timeout` |integer |`240` |Timeout in seconds for waiting on CI checks (30-600)
+|===
+
 ==== Pyprojectx Section
 
 |===
@@ -156,6 +165,11 @@ sonar:
 pages:
   reference: cui-java-tools
   deploy-at-release: true
+
+# GitHub Automation (controls auto-merge of workflow update PRs)
+github-automation:
+  auto-merge-build-versions: true
+  auto-merge-build-timeout: 240
 ----
 
 == Fallback Behavior

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -200,6 +200,45 @@ class TestPyprojectxSection:
         assert "pyprojectx-verify-command=./pw quality-gate" in result.stdout
 
 
+class TestGitHubAutomationSection:
+    """Test github-automation configuration section."""
+
+    def test_default_auto_merge_values(self, temp_dir):
+        """Should provide default github-automation values when not configured."""
+        result = run_script(SCRIPT_PATH, "--config", str(temp_dir / "nonexistent.yml"))
+        assert result.returncode == 0
+        assert "auto-merge-build-versions=true" in result.stdout
+        assert "auto-merge-build-timeout=240" in result.stdout
+
+    def test_auto_merge_disabled(self, temp_dir):
+        """Should read auto-merge-build-versions as false."""
+        config = temp_dir / "project.yml"
+        config.write_text("github-automation:\n  auto-merge-build-versions: false")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "auto-merge-build-versions=false" in result.stdout
+
+    def test_custom_timeout(self, temp_dir):
+        """Should read custom auto-merge-build-timeout."""
+        config = temp_dir / "project.yml"
+        config.write_text("github-automation:\n  auto-merge-build-timeout: 300")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "auto-merge-build-timeout=300" in result.stdout
+
+    def test_combined_settings(self, temp_dir):
+        """Should read both github-automation settings together."""
+        config = temp_dir / "project.yml"
+        config.write_text("""github-automation:
+  auto-merge-build-versions: true
+  auto-merge-build-timeout: 120
+""")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "auto-merge-build-versions=true" in result.stdout
+        assert "auto-merge-build-timeout=120" in result.stdout
+
+
 class TestEdgeCases:
     """Test edge cases and error handling."""
 

--- a/test/workflow/test_update_consumer_repo.py
+++ b/test/workflow/test_update_consumer_repo.py
@@ -1,5 +1,6 @@
-"""Tests for update-consumer-repo.py argument validation."""
+"""Tests for update-consumer-repo.py argument validation and auto-merge config."""
 
+import importlib.util
 import sys
 from pathlib import Path
 
@@ -9,6 +10,14 @@ from conftest import PROJECT_ROOT, run_script
 
 SCRIPT_PATH = PROJECT_ROOT / "workflow-scripts/update-consumer-repo.py"
 VALID_SHA = "abcdef1234567890abcdef1234567890abcdef12"
+
+
+def _load_module():
+    """Load update-consumer-repo.py as a module for unit testing."""
+    spec = importlib.util.spec_from_file_location("update_consumer_repo", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 class TestArgumentValidation:
@@ -71,3 +80,73 @@ class TestArgumentValidation:
         )
         # Will fail on clone but should accept the org argument
         assert "Processing custom-org/test" in result.stdout
+
+
+class TestAutoMergeConfig:
+    """Test read_auto_merge_config function."""
+
+    def test_no_project_yml(self, temp_dir):
+        """Should return defaults when project.yml doesn't exist."""
+        mod = _load_module()
+        config = mod.read_auto_merge_config(temp_dir)
+        assert config["enabled"] is True
+        assert config["timeout"] == 240
+
+    def test_no_github_automation_section(self, temp_dir):
+        """Should return defaults when github-automation section is missing."""
+        mod = _load_module()
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "project.yml").write_text("name: test-repo\n")
+        config = mod.read_auto_merge_config(temp_dir)
+        assert config["enabled"] is True
+        assert config["timeout"] == 240
+
+    def test_auto_merge_disabled(self, temp_dir):
+        """Should read disabled auto-merge setting."""
+        mod = _load_module()
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "project.yml").write_text(
+            "github-automation:\n  auto-merge-build-versions: false\n"
+        )
+        config = mod.read_auto_merge_config(temp_dir)
+        assert config["enabled"] is False
+        assert config["timeout"] == 240
+
+    def test_custom_timeout(self, temp_dir):
+        """Should read custom timeout value."""
+        mod = _load_module()
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "project.yml").write_text(
+            "github-automation:\n  auto-merge-build-timeout: 120\n"
+        )
+        config = mod.read_auto_merge_config(temp_dir)
+        assert config["enabled"] is True
+        assert config["timeout"] == 120
+
+    def test_both_settings(self, temp_dir):
+        """Should read both settings correctly."""
+        mod = _load_module()
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "project.yml").write_text(
+            "github-automation:\n"
+            "  auto-merge-build-versions: true\n"
+            "  auto-merge-build-timeout: 300\n"
+        )
+        config = mod.read_auto_merge_config(temp_dir)
+        assert config["enabled"] is True
+        assert config["timeout"] == 300
+
+    def test_invalid_yaml(self, temp_dir):
+        """Should return defaults on invalid YAML."""
+        mod = _load_module()
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "project.yml").write_text(": invalid: yaml: [broken")
+        config = mod.read_auto_merge_config(temp_dir)
+        # Should fall back to defaults on parse error
+        assert config["enabled"] is True
+        assert config["timeout"] == 240

--- a/workflow-scripts/update-consumer-repo.py
+++ b/workflow-scripts/update-consumer-repo.py
@@ -5,15 +5,27 @@ This script encapsulates the per-repository update logic from the release
 workflow. It clones a repository, runs the update-workflow-references.py
 script, and creates a PR if changes were made.
 
+When the consumer repo has auto-merge enabled in its project.yml, the script
+will poll PR checks and auto-merge when CI passes.
+
 Usage:
     ./update-consumer-repo.py --repo cui-java-tools --version 0.1.0 --sha abc123...
 """
 
 import argparse
+import json
+import os
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
+
+# Result status constants
+STATUS_PR_CREATED_AND_MERGED = "pr_created_and_merged"
+STATUS_PR_CREATED = "pr_created"
+STATUS_NO_CHANGES = "no_changes"
+STATUS_ERROR = "error"
 
 
 def run_gh(
@@ -34,12 +46,164 @@ def run_git(
     )
 
 
+def write_summary(text: str) -> None:
+    """Append markdown text to GitHub Actions step summary.
+
+    No-op when GITHUB_STEP_SUMMARY is not set (e.g. running locally).
+    """
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(text + "\n")
+
+
+def read_auto_merge_config(repo_dir: Path) -> dict:
+    """Read auto-merge configuration from the consumer repo's project.yml.
+
+    Returns a dict with:
+        enabled: bool (default True)
+        timeout: int in seconds (default 240)
+    """
+    config = {"enabled": True, "timeout": 240}
+    project_yml = repo_dir / ".github" / "project.yml"
+
+    if not project_yml.exists():
+        return config
+
+    try:
+        import yaml
+    except ImportError:
+        print("::warning::PyYAML not available, using auto-merge defaults")
+        return config
+
+    try:
+        with open(project_yml, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            return config
+
+        automation = data.get("github-automation", {})
+        if not isinstance(automation, dict):
+            return config
+
+        if "auto-merge-build-versions" in automation:
+            config["enabled"] = bool(automation["auto-merge-build-versions"])
+
+        if "auto-merge-build-timeout" in automation:
+            try:
+                config["timeout"] = int(automation["auto-merge-build-timeout"])
+            except (ValueError, TypeError):
+                pass
+
+    except Exception as e:
+        print(f"::warning::Failed to read auto-merge config: {e}")
+
+    return config
+
+
+def auto_merge_pr(full_repo: str, pr_url: str, timeout: int) -> bool:
+    """Poll PR checks and merge when all pass.
+
+    Args:
+        full_repo: Full repo name (e.g. "cuioss/cui-java-tools")
+        pr_url: URL of the PR to merge
+        timeout: Maximum seconds to wait for checks
+
+    Returns:
+        True if PR was merged, False otherwise.
+    """
+    print(f"Auto-merge: waiting for checks on {pr_url} (timeout: {timeout}s)")
+    poll_interval = 15
+    elapsed = 0
+
+    # Give CI a moment to register checks
+    time.sleep(10)
+    elapsed += 10
+
+    while elapsed < timeout:
+        result = run_gh(
+            [
+                "pr",
+                "checks",
+                pr_url,
+                "--json",
+                "name,state,conclusion",
+            ],
+            check=False,
+        )
+
+        if result.returncode != 0:
+            print(f"::warning::Failed to fetch PR checks: {result.stderr}")
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            continue
+
+        try:
+            checks = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            print(f"::warning::Invalid JSON from pr checks: {result.stdout}")
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            continue
+
+        if not checks:
+            print("  No checks registered yet, waiting...")
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            continue
+
+        # Check for failures
+        failed = [c for c in checks if c.get("conclusion") == "FAILURE"]
+        if failed:
+            names = ", ".join(c.get("name", "unknown") for c in failed)
+            print(f"::warning::Auto-merge aborted: checks failed ({names})")
+            return False
+
+        # Check if all completed
+        pending = [c for c in checks if c.get("state") != "COMPLETED"]
+        if not pending:
+            # All checks completed with no failures
+            print("All checks passed, merging PR...")
+            merge_result = run_gh(
+                [
+                    "pr",
+                    "merge",
+                    pr_url,
+                    "--squash",
+                    "--delete-branch",
+                ],
+                check=False,
+            )
+            if merge_result.returncode == 0:
+                print(f"✓ PR merged: {pr_url}")
+                return True
+            else:
+                print(f"::warning::Merge failed: {merge_result.stderr}")
+                return False
+
+        pending_names = ", ".join(c.get("name", "unknown") for c in pending)
+        print(f"  Waiting for checks: {pending_names} ({elapsed}s/{timeout}s)")
+
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
+    print(f"::warning::Auto-merge timed out after {timeout}s, leaving PR open")
+    return False
+
+
+def make_result(status: str, pr_url: str | None = None, error: str | None = None) -> dict:
+    """Create a standardized result dict."""
+    return {"status": status, "pr_url": pr_url, "error": error}
+
+
 def update_consumer_repo(
     org: str, repo: str, version: str, sha: str, script_dir: Path
-) -> bool:
+) -> dict:
     """Update a single consumer repository.
 
-    Returns True if PR was created, False if no changes needed or on error.
+    Returns a result dict with status, pr_url, and error fields.
     """
     full_repo = f"{org}/{repo}"
     branch = f"chore/update-org-workflows-v{version}"
@@ -58,7 +222,7 @@ def update_consumer_repo(
         if result.returncode != 0:
             print(f"::warning::Failed to clone {full_repo}: {result.stderr}")
             print("::endgroup::")
-            return False
+            return make_result(STATUS_ERROR, error=f"Clone failed: {result.stderr.strip()}")
 
         # Configure git credential helper to use GH_TOKEN for push operations
         # gh repo clone sets up HTTPS remote but git push needs explicit auth
@@ -72,7 +236,10 @@ def update_consumer_repo(
         if not (repo_dir / ".github" / "workflows").exists():
             print(f"::warning::No .github/workflows directory in {repo}, skipping")
             print("::endgroup::")
-            return False
+            return make_result(STATUS_ERROR, error="No .github/workflows directory")
+
+        # Read auto-merge config before running update (uses cloned repo's project.yml)
+        auto_merge_config = read_auto_merge_config(repo_dir)
 
         # Run update script
         print("Updating workflow references...")
@@ -100,7 +267,7 @@ def update_consumer_repo(
         if diff_result.returncode == 0:
             print("No changes needed")
             print("::endgroup::")
-            return False
+            return make_result(STATUS_NO_CHANGES)
 
         # Create branch
         run_git(["checkout", "-b", branch], cwd=repo_dir)
@@ -128,7 +295,7 @@ def update_consumer_repo(
         if result.returncode != 0:
             print(f"::warning::Failed to push: {result.stderr}")
             print("::endgroup::")
-            return False
+            return make_result(STATUS_ERROR, error=f"Push failed: {result.stderr.strip()}")
         print("Push successful")
 
         # Create PR (--head is required for shallow clones in temp directories)
@@ -154,13 +321,25 @@ def update_consumer_repo(
             cwd=repo_dir,
         )
 
-        if result.returncode == 0:
-            print(f"✓ PR created: {result.stdout.strip()}")
-        else:
+        if result.returncode != 0:
             print(f"::warning::PR creation failed: {result.stderr}")
+            print("::endgroup::")
+            return make_result(STATUS_ERROR, error=f"PR creation failed: {result.stderr.strip()}")
+
+        pr_url = result.stdout.strip()
+        print(f"✓ PR created: {pr_url}")
+
+        # Attempt auto-merge if enabled
+        if auto_merge_config["enabled"]:
+            print(f"Auto-merge enabled for {full_repo}")
+            merged = auto_merge_pr(full_repo, pr_url, auto_merge_config["timeout"])
+            status = STATUS_PR_CREATED_AND_MERGED if merged else STATUS_PR_CREATED
+        else:
+            print(f"Auto-merge disabled for {full_repo}, leaving PR open")
+            status = STATUS_PR_CREATED
 
         print("::endgroup::")
-        return result.returncode == 0
+        return make_result(status, pr_url=pr_url)
 
 
 def main() -> None:
@@ -184,9 +363,15 @@ def main() -> None:
         sys.exit(1)
 
     script_dir = Path(__file__).parent
-    success = update_consumer_repo(
+    result = update_consumer_repo(
         args.org, args.repo, args.version, args.sha, script_dir
     )
+
+    # Output result as parseable JSON line for the release workflow
+    print(f"RESULT:{json.dumps(result)}")
+
+    # Exit with appropriate code
+    success = result["status"] in (STATUS_PR_CREATED, STATUS_PR_CREATED_AND_MERGED, STATUS_NO_CHANGES)
     sys.exit(0 if success else 1)
 
 


### PR DESCRIPTION
## Summary
- Add `github-automation` section to `project.yml` schema with `auto-merge-build-versions` (boolean, default true) and `auto-merge-build-timeout` (integer, default 240s)
- Release workflow now polls CI checks on consumer repo PRs and auto-merges when enabled
- Structured release summary written to `GITHUB_STEP_SUMMARY` with version, SHA, and per-repo PR outcomes table

## Changes
- **`workflow-scripts/update-consumer-repo.py`** — Added `read_auto_merge_config()`, `auto_merge_pr()`, `write_summary()` functions; changed return type to result dict; outputs `RESULT:{json}` line
- **`read-project-config/read-config.py`** — Added `auto-merge-build-versions` and `auto-merge-build-timeout` to `FIELD_REGISTRY`
- **`read-project-config/action.yml`** — Added two new outputs for the github-automation section
- **`read-project-config/schema.json`** — Added `github-automation` object with boolean and integer properties
- **`.github/workflows/release.yml`** — Modified consumer loop to collect JSON results and build `GITHUB_STEP_SUMMARY` table
- **Documentation** — Updated README.adoc, project-yml-schema.adoc, update-github-actions.md, setup-consumer-repo.md
- **Tests** — 10 new tests (4 for `TestGitHubAutomationSection`, 6 for `TestAutoMergeConfig`), all 104 tests pass

## Test plan
- [x] `./pw verify` passes (compile + quality-gate + 104 tests)
- [ ] Merge this PR
- [ ] Add `github-automation` config to cui-java-tools (auto-merge: false) and cui-java-module-template (auto-merge: true)
- [ ] Release v0.2.5 and verify: template repo PR auto-merged, tools repo PR left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)