### PR TITLE
chore: prepare release 0.2.5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.4
+  current-version: 0.2.5
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary
- Bump current-version to 0.2.5
- Includes auto-merge consumer repo PRs feature and release summary

## Test plan
- [ ] CI passes
- [ ] Merge and trigger release workflow via workflow_dispatch
- [ ] Verify consumer repo PRs: cui-java-module-template auto-merged, cui-java-tools left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)