### PR TITLE
fix: use correct gh pr checks fields and update timeout defaults

### DIFF
--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -206,7 +206,7 @@ Consumer repos can configure auto-merge behavior for workflow update PRs in thei
 ```yaml
 github-automation:
   auto-merge-build-versions: true   # Auto-merge when CI passes (default: true)
-  auto-merge-build-timeout: 240     # Seconds to wait for CI (default: 240, range: 30-600)
+  auto-merge-build-timeout: 300     # Seconds to wait for CI (default: 300, range: 30-1800)
 ```
 
 When auto-merge is enabled, the release workflow will poll CI checks and automatically squash-merge the PR once all checks pass. If checks fail or timeout, the PR is left open for manual review.

--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -151,7 +151,7 @@ pages:
 
 github-automation:
   auto-merge-build-versions: true
-  auto-merge-build-timeout: 240
+  auto-merge-build-timeout: 300
 ```
 
 ## Custom Fields Extension

--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -164,7 +164,7 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 | Auto-merge consumer repo workflow update PRs when CI passes
 
 | `auto-merge-build-timeout`
-| `'240'`
+| `'300'`
 | Timeout in seconds for waiting on CI checks before auto-merge
 |===
 

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -56,7 +56,7 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["pyprojectx", "verify-command"], "pyprojectx-verify-command", "./pw verify", None),
     # github-automation section
     (["github-automation", "auto-merge-build-versions"], "auto-merge-build-versions", True, None),
-    (["github-automation", "auto-merge-build-timeout"], "auto-merge-build-timeout", 240, None),
+    (["github-automation", "auto-merge-build-timeout"], "auto-merge-build-timeout", 300, None),
     # consumers list (special case: transform list to space-separated string)
     (["consumers"], "consumers", [], lambda x: " ".join(x) if isinstance(x, list) else ""),
 ]

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -157,9 +157,9 @@
         "auto-merge-build-timeout": {
           "type": "integer",
           "description": "Timeout in seconds for waiting on CI checks before auto-merge",
-          "default": 240,
+          "default": 300,
           "minimum": 30,
-          "maximum": 600
+          "maximum": 1800
         }
       },
       "additionalProperties": false

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -118,7 +118,7 @@ jobs:
 |Field |Type |Default |Description
 
 |`github-automation.auto-merge-build-versions` |boolean |`true` |Auto-merge workflow update PRs when CI checks pass
-|`github-automation.auto-merge-build-timeout` |integer |`240` |Timeout in seconds for waiting on CI checks (30-600)
+|`github-automation.auto-merge-build-timeout` |integer |`300` |Timeout in seconds for waiting on CI checks (30-1800)
 |===
 
 ==== Pyprojectx Section
@@ -169,7 +169,7 @@ pages:
 # GitHub Automation (controls auto-merge of workflow update PRs)
 github-automation:
   auto-merge-build-versions: true
-  auto-merge-build-timeout: 240
+  auto-merge-build-timeout: 300
 ----
 
 == Fallback Behavior

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -208,7 +208,7 @@ class TestGitHubAutomationSection:
         result = run_script(SCRIPT_PATH, "--config", str(temp_dir / "nonexistent.yml"))
         assert result.returncode == 0
         assert "auto-merge-build-versions=true" in result.stdout
-        assert "auto-merge-build-timeout=240" in result.stdout
+        assert "auto-merge-build-timeout=300" in result.stdout
 
     def test_auto_merge_disabled(self, temp_dir):
         """Should read auto-merge-build-versions as false."""

--- a/test/workflow/test_update_consumer_repo.py
+++ b/test/workflow/test_update_consumer_repo.py
@@ -90,7 +90,7 @@ class TestAutoMergeConfig:
         mod = _load_module()
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is True
-        assert config["timeout"] == 240
+        assert config["timeout"] == 300
 
     def test_no_github_automation_section(self, temp_dir):
         """Should return defaults when github-automation section is missing."""
@@ -100,7 +100,7 @@ class TestAutoMergeConfig:
         (github_dir / "project.yml").write_text("name: test-repo\n")
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is True
-        assert config["timeout"] == 240
+        assert config["timeout"] == 300
 
     def test_auto_merge_disabled(self, temp_dir):
         """Should read disabled auto-merge setting."""
@@ -112,7 +112,7 @@ class TestAutoMergeConfig:
         )
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is False
-        assert config["timeout"] == 240
+        assert config["timeout"] == 300
 
     def test_custom_timeout(self, temp_dir):
         """Should read custom timeout value."""
@@ -149,4 +149,4 @@ class TestAutoMergeConfig:
         config = mod.read_auto_merge_config(temp_dir)
         # Should fall back to defaults on parse error
         assert config["enabled"] is True
-        assert config["timeout"] == 240
+        assert config["timeout"] == 300


### PR DESCRIPTION
## Summary
- Fixed `auto_merge_pr` to use `--json name,state,bucket` instead of `name,state,conclusion` (field doesn't exist in `gh pr checks`)
- Updated default timeout from 240 to 300 seconds across all config, docs, and tests
- Updated schema maximum timeout from 600 to 1800 (30 minutes)

## Context
The v0.2.5 release auto-merge for cui-java-module-template timed out because every `gh pr checks` poll failed with "Unknown JSON field: conclusion". The function never actually read check status.

## Test plan
- [x] All 104 tests pass (`./pw verify`)
- [ ] After merge, re-release to verify auto-merge works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)