### PR TITLE
chore: prepare release 0.2.6

### DIFF
--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -22,7 +22,7 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 
 - name: Read project.yml configuration
   id: config
-  uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+  uses: cuioss/cuioss-organization/.github/actions/read-project-config@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
 
 - name: Use configuration
   run: |
@@ -34,7 +34,7 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 
 [source,yaml]
 ----
-- uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+- uses: cuioss/cuioss-organization/.github/actions/read-project-config@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
   id: config
   with:
     config-path: 'custom/path/project.yml'
@@ -228,7 +228,7 @@ custom:
 
 [source,yaml]
 ----
-- uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+- uses: cuioss/cuioss-organization/.github/actions/read-project-config@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
   id: config
 
 - name: Run E2E tests

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.5
+  current-version: 0.2.6
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)

--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@v0.2.5
 
   build:
     needs: config

--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@v0.2.5
 
       - name: Set up JDK ${{ steps.config.outputs.java-version || inputs.java-version }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@v0.2.5
 
       - name: Set up Python ${{ steps.config.outputs.pyprojectx-python-version || inputs.python-version }}
         if: ${{ (steps.config.outputs.pyprojectx-python-version || inputs.python-version) != '' }}

--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ Replace inline workflows with reusable workflow callers:
 # In your repo's .github/workflows/maven.yml
 jobs:
   build:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -131,7 +131,7 @@ jobs:
   build:
     # Run on push, OR on pull_request only if from a fork
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
@@ -217,7 +217,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -298,7 +298,7 @@ permissions:
 
 jobs:
   analysis:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     permissions:
       security-events: write
       id-token: write
@@ -338,7 +338,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     permissions:
       contents: read
       pull-requests: write
@@ -387,7 +387,7 @@ jobs:
   verify:
     # Run on push, OR on pull_request only if from a fork
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
 ----
 
 === Inputs

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -49,7 +49,7 @@ permissions:
 jobs:
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}

--- a/docs/workflow-examples/dependency-review-caller.yml
+++ b/docs/workflow-examples/dependency-review-caller.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     permissions:
       contents: read
       pull-requests: write

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -16,7 +16,7 @@ jobs:
     # Run on push events, OR on pull_request only if from a fork
     # This prevents duplicate runs: push handles internal branches, PR handles forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     with:
       # Override project.yml settings with explicit inputs
       java-versions: '["21","25"]'

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -17,7 +17,7 @@ jobs:
     # Run on push events, OR on pull_request only if from a fork
     # This prevents duplicate runs: push handles internal branches, PR handles forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}

--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -17,7 +17,7 @@ jobs:
     # Run on push events, OR on pull_request only if from a fork
     # This prevents duplicate runs: push handles internal branches, PR handles forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     # Optional inputs (all have sensible defaults):
     # with:
     #   python-version: '3.12'           # Leave empty to let uv manage from pyproject.toml

--- a/docs/workflow-examples/scorecards-caller.yml
+++ b/docs/workflow-examples/scorecards-caller.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   analysis:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@9dd309ec67298fce248733e0b7f5b7f703836f34 # v0.2.5
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@1a304918c109bc41ee7df597d5d9ab4555ce3f56 # v0.2.6
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
## Summary
- Bump version to 0.2.6
- Update workflow SHA references

## Changes since v0.2.5
- fix: use correct `gh pr checks` fields (`name,state,bucket` instead of `name,state,conclusion`)
- Update default auto-merge timeout to 300s, max to 1800s

🤖 Generated with [Claude Code](https://claude.com/claude-code)