### PR TITLE
fix: ensure FUNDING.yml for all repos, not just templates

### DIFF
--- a/.claude/commands/verify-org-integration.md
+++ b/.claude/commands/verify-org-integration.md
@@ -7,7 +7,7 @@ Identifies and removes:
 - Duplicate community health files (CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md)
 
 Identifies and adds:
-- Missing `.github/FUNDING.yml` for template repositories (these don't inherit from org `.github` repo)
+- Missing `.github/FUNDING.yml` (org-level inheritance is unreliable for the sponsor button)
 - Missing GitHub labels referenced by `.github/dependabot.yml`
 
 ## Workflow
@@ -39,11 +39,10 @@ Identifies and adds:
      - Options: List each file as an option + "Keep all files"
      - Default recommendation: Select all for removal
 
-5. **Ensure FUNDING.yml for Template Repos**
-   - Check if the repo is a template: `gh api repos/cuioss/{repo-name} --jq '.is_template'`
-   - If `true`, check if `.github/FUNDING.yml` exists in the local repo at `~/git/{repo-name}/.github/FUNDING.yml`
+5. **Ensure FUNDING.yml**
+   - Check if `.github/FUNDING.yml` exists in the local repo at `~/git/{repo-name}/.github/FUNDING.yml`
    - If missing, create it with content `github: cuioss`
-   - Template repos don't inherit community health files (including FUNDING.yml) from the org `.github` repo, so this must be added explicitly
+   - FUNDING.yml inheritance from the org `.github` repo is unreliable for producing the sponsor button, so each repo needs an explicit copy
 
 6. **Ensure Dependabot Labels**
    - Check if `.github/dependabot.yml` exists in the local repo at `~/git/{repo-name}/.github/dependabot.yml`
@@ -128,8 +127,8 @@ Files that should remain repo-specific (never flagged):
 - `CLAUDE.md`
 - `.github/dependabot.yml`
 
-### FUNDING.yml (Template Repos Only)
-Template repositories (`is_template: true`) don't inherit community health files from the org `.github` repo.
+### FUNDING.yml
+FUNDING.yml inheritance from the org `.github` repo is unreliable for producing the sponsor button.
 If `.github/FUNDING.yml` is missing, it will be created with `github: cuioss`.
 
 ### Dependabot Labels


### PR DESCRIPTION
## Summary
- Update `verify-org-integration` command to check FUNDING.yml on all repos, not just template repos
- FUNDING.yml inheritance from the org `.github` repo is unreliable for producing the sponsor button

## Context
cui-java-tools was missing the sponsor button because it had no explicit `.github/FUNDING.yml`. The org `.github` repo has the file, but inheritance doesn't reliably produce the button. The `verify-org-integration` command previously only added FUNDING.yml for template repos (`is_template: true`). Now it checks all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)