### PR TITLE
chore: add cui-test-generator to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -10,3 +10,4 @@ release:
 consumers:
   - cui-java-module-template
   - cui-java-tools
+  - cui-test-generator


### PR DESCRIPTION
## Summary
- Add cui-test-generator to the consumers list in project.yml after successful workflow migration