### PR TITLE
chore: document branch protection git workflow in CLAUDE.md and commands

### DIFF
--- a/.claude/commands/apply-branch-protection.md
+++ b/.claude/commands/apply-branch-protection.md
@@ -14,13 +14,16 @@ Apply cuioss organization branch protection rulesets to a single repository with
 
 3. **Ask User for Required Status Checks**
    - Use AskUserQuestion with multiSelect=true
-   - Filter discovered checks to include only build and analysis jobs:
-     - `build (21)`, `build (25)` - Matrix build jobs
-     - `sonar-build` - SonarCloud analysis
-   - Exclude auxiliary checks: `deploy-snapshot`, `Dependabot`
+   - Filter discovered checks to include only build and analysis jobs
+   - Exclude auxiliary checks: `deploy-snapshot`, `Dependabot`, `config`
    - Always include "None (no required checks)" option
    - Header: "Status checks"
    - Question: "Which status checks should be required to pass before merging?"
+   - **IMPORTANT - Check name format depends on workflow type**:
+     - **Reusable workflow callers** (target state): Check names are prefixed with the calling job name, e.g. `build / build (21)`, `build / build (25)`, `build / sonar-build`
+     - **Inline workflows** (legacy): Check names are unprefixed, e.g. `build (21)`, `build (25)`, `sonar-build`
+   - When migrating from inline to reusable workflows, the check names CHANGE. Use the prefixed names that the reusable workflow will produce, not the legacy names from `--list-checks`
+   - The standard required checks for repos using the reusable workflow are: `build / build (21)`, `build / build (25)`, `build / sonar-build`
 
 4. **Ask User for Required Reviews**
    - Use AskUserQuestion

--- a/.claude/commands/verify-org-integration.md
+++ b/.claude/commands/verify-org-integration.md
@@ -67,11 +67,17 @@ Identifies and adds:
      - Parse the JSON output for results
 
 8. **Commit & Push** (if files were changed)
-   - If files were removed or added, in the local repo directory:
-     - `git -C ~/git/{repo-name} add -A`
-     - `git -C ~/git/{repo-name} commit -m "chore: align with org-level community health files"`
-   - AskUserQuestion: "Push changes to remote?"
-   - If yes: `git -C ~/git/{repo-name} push`
+   - **Skip this step when called from `/setup-consumer-repo`** — the parent orchestrator handles commit/push in its own step after all sub-commands have run
+   - If running standalone and files were removed or added:
+     - All cuioss repos have branch protection — cannot push directly to main
+     - Create a branch: `git -C ~/git/{repo-name} checkout -b chore/align-org-health-files`
+     - Stage and commit: `git -C ~/git/{repo-name} add -A && git -C ~/git/{repo-name} commit -m "chore: align with org-level community health files"`
+     - Push: `git -C ~/git/{repo-name} push -u origin chore/align-org-health-files`
+     - Create PR: `gh pr create --repo cuioss/{repo-name} --head chore/align-org-health-files --base main --title "chore: align with org-level community health files" --body "..."`
+     - Wait for CI: `gh pr checks --repo cuioss/{repo-name} --watch`
+     - AskUserQuestion: "Merge the PR?"
+     - If yes: `gh pr merge --repo cuioss/{repo-name} --squash --delete-branch`
+     - Return to main: `git -C ~/git/{repo-name} checkout main && git -C ~/git/{repo-name} pull`
 
 9. **Report Summary**
    - Display final status:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,20 @@ Both use `config.json` to define:
 
 **Organization-level** (shared): `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `PAGES_DEPLOY_TOKEN`, `SONAR_TOKEN`
 
+## Git Workflow
+
+All cuioss repositories have branch protection on `main`. Direct pushes to `main` are never allowed. Always use this workflow:
+
+1. Create a feature branch: `git checkout -b <branch-name>`
+2. Commit changes: `git add <files> && git commit -m "<message>"`
+3. Push the branch: `git push -u origin <branch-name>`
+4. Create a PR: `gh pr create --repo cuioss/<repo> --head <branch-name> --base main --title "<title>" --body "<body>"`
+5. Wait for CI: `gh pr checks --repo cuioss/<repo> --watch`
+6. Merge when checks pass: `gh pr merge --repo cuioss/<repo> --squash --delete-branch`
+7. Return to main: `git checkout main && git pull`
+
+This applies to both this repository and all consumer repositories.
+
 ## Related Repository
 
 https://github.com/cuioss/.github - Organization-wide community health files (SECURITY.md, CONTRIBUTING.md, issue templates) automatically inherited by all repos.


### PR DESCRIPTION
## Summary
- Add Git Workflow section to CLAUDE.md documenting that direct push to main is never allowed
- Fix all command files to use branch+PR workflow consistently for both cuioss-organization and consumer repos
- Document reusable workflow check name prefixing in apply-branch-protection

## Changes
- `CLAUDE.md`: New "Git Workflow" section
- `setup-consumer-repo.md`: Fixed PR creation flags, consumers list workflow, check name warning
- `apply-branch-protection.md`: Documented prefixed vs unprefixed check names
- `update-github-actions.md`: Branch+PR for standalone and consumers list
- `verify-org-integration.md`: Branch+PR for standalone, skip when orchestrated