### PR TITLE
chore: add cui-test-juli-logger to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -11,3 +11,4 @@ consumers:
   - cui-java-module-template
   - cui-java-tools
   - cui-test-generator
+  - cui-test-juli-logger


### PR DESCRIPTION
Add cui-test-juli-logger to consumers list after workflow migration