### PR TITLE
fix: move contents:write to job-level in release caller template

### DIFF
--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -113,6 +113,18 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
       - **Org policy**: If it requires organizational changes (e.g., branch protection, required reviews)
       - **Will improve**: If it improves over time with consistent workflow usage (e.g., SAST coverage, CI test ratio)
       - **Not actionable**: If it requires effort disproportionate to the repo (e.g., fuzzing, OpenSSF badge)
+    - **Auto-dismiss known false positives**:
+      - After presenting the scorecard table, automatically dismiss alerts that are inherent to the cuioss workflow design:
+        - `TokenPermissionsID` on `scorecards.yml` (line containing `security-events: write`) — the Scorecard action requires this permission to upload SARIF results. This is a [known Scorecard limitation](https://github.com/ossf/scorecard/issues/4762).
+      - For each matching alert:
+        ```
+        gh api --method PATCH \
+          "repos/cuioss/{repo-name}/code-scanning/alerts/{alert-number}" \
+          -f state='dismissed' \
+          -f dismissed_reason='false positive' \
+          -f dismissed_comment='security-events:write is required by the Scorecard action to upload SARIF results. Known limitation: ossf/scorecard#4762'
+        ```
+      - Report dismissed alerts in the summary table with classification "Auto-dismissed (false positive)"
     - If any alerts are classified as **Fixed**, create a follow-up fix branch, apply changes, create PR, wait for CI, and merge
     - Report the final table to the user
 

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.6
+  current-version: 0.2.7
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)

--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -10,10 +10,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
+    permissions:
+      contents: write
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@fade192ad04c25a64cab26a8d931b7d389b6fb79 # v0.2.6
     secrets:


### PR DESCRIPTION
## Summary
- Move `contents: write` from top-level to job-level in `maven-release-caller.yml` template to resolve OpenSSF Scorecard `TokenPermissionsID` alerts on consumer repos
- Bump version to `0.2.7` so the fix gets distributed to consumers via release
- Add auto-dismiss step for known Scorecard false positives (`security-events: write` on `scorecards.yml`) to the `setup-consumer-repo` command

## Details

The Scorecard check flags `contents: write` at the workflow top-level as overly broad. Moving it to job-level gives a 10/10 score. This is safe because the reusable release workflow uses a GitHub App token for all write operations, not `GITHUB_TOKEN`.

Proven by `cui-java-module-template` which already runs with `contents: read` at top-level.

## Test plan
- [ ] Verify template has `contents: read` at top-level and `contents: write` at job-level
- [ ] After release v0.2.7: verify consumer PRs are created with updated `release.yml`
- [ ] After consumer merges: next Scorecard run should not flag `TokenPermissionsID` on `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)