### PR TITLE
fix: use Maven tag for GitHub Release instead of v-prefixed duplicate

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -136,7 +136,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           token: ${{ steps.release-token.outputs.token }}
-          tag_name: v${{ steps.config.outputs.current-version }}
-          name: v${{ steps.config.outputs.current-version }}
+          tag_name: ${{ steps.config.outputs.current-version }}
+          name: ${{ steps.config.outputs.current-version }}
           generate_release_notes: true
           make_latest: true


### PR DESCRIPTION
## Summary
- Remove `v` prefix from `tag_name` and `name` in the GitHub Release step of `reusable-maven-release.yml`
- The maven-release-plugin already creates a version tag (e.g., `2.5.2`). The GitHub Release step was creating a second `v`-prefixed tag (`v2.5.2`), causing auto-generated release notes to compare between the two near-identical tags and show no meaningful changes.

## Cleanup applied
- Retagged existing GitHub Releases on `cui-java-tools` and `cui-test-generator` from `v`-prefixed to Maven tag
- Deleted duplicate `v`-prefixed tags: `v2.6.2` (cui-java-tools), `v2.5.2` (cui-test-generator)

## Test plan
- [ ] Next release on a consumer repo should create only one tag (Maven's) and correct release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)