### PR TITLE
chore: prepare release 0.2.8

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.7
+  current-version: 0.2.8
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary
- Version bump to 0.2.8

## Changes included since v0.2.7
- fix: use Maven tag for GitHub Release instead of v-prefixed duplicate (#49)
- fix: remove FUNDING.yml creation, flag repo-level copies as redundant (#50)

This release will distribute the tag fix to all consumer repos, preventing duplicate `v`-prefixed tags on future releases.