### PR TITLE
chore: add cui-test-value-objects to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -12,3 +12,4 @@ consumers:
   - cui-java-tools
   - cui-test-generator
   - cui-test-juli-logger
+  - cui-test-value-objects


### PR DESCRIPTION
Add cui-test-value-objects to consumers list after workflow migration