### PR TITLE
chore: add cui-jsf-test-basic to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -13,3 +13,4 @@ consumers:
   - cui-test-generator
   - cui-test-juli-logger
   - cui-test-value-objects
+  - cui-jsf-test-basic


### PR DESCRIPTION
Add cui-jsf-test-basic to consumers list after workflow migration