### PR TITLE
chore: add sidebar homepage section detection to apply-repo-settings

### DIFF
--- a/.claude/commands/apply-repo-settings.md
+++ b/.claude/commands/apply-repo-settings.md
@@ -33,6 +33,13 @@ Apply cuioss organization repository settings to a single repository with previe
    - If confirmed, run `./repo-settings/setup-repo-settings.py --repo {repo-name} --apply`
    - Report success or any warnings from the script
 
+6. **Check Sidebar Sections**
+   - The apply step already checks sidebar sections and emits warnings
+   - If warnings mention "Packages" or "Environments" sidebar items:
+     - Report the unwanted sections to the user
+     - Provide direct links: `https://github.com/cuioss/{repo-name}` → gear icon on About section
+     - Note: These toggles have no API and must be changed manually in the web UI
+
 ## Arguments
 
 - `$ARGUMENTS` - Optional repository name (passed to repo-selection skill)
@@ -56,3 +63,4 @@ From `config.json`:
 - **Features**: issues, wiki, projects, discussions toggles
 - **Merge**: squash/merge/rebase options, delete branch on merge, commit message format
 - **Security**: vulnerability reporting, Dependabot, secret scanning
+- **Homepage** (advisory): sidebar toggles for Packages, Releases, Environments (no API — manual only)

--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -24,24 +24,31 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
    - This applies: features, merge options, security settings
    - Follow the interactive prompts to confirm changes
 
-5. **Update GitHub Actions**
+5. **Check Sidebar Sections**
+   - The apply-repo-settings step already checks sidebar sections and emits warnings
+   - If warnings mention "Packages" or "Environments" sidebar items:
+     - Report the unwanted sections to the user
+     - Provide direct link: `https://github.com/cuioss/{repo-name}` → gear icon on About section
+     - Note: These toggles have no API and must be changed manually in the web UI
+
+6. **Update GitHub Actions**
    - Run `/update-github-actions {repo-name}`
    - This synchronizes: workflow files from caller templates, project.yml configuration
    - Follow the interactive prompts to confirm each workflow update
 
-6. **Apply Branch Protection**
+7. **Apply Branch Protection**
    - Run `/apply-branch-protection {repo-name}`
    - This configures: branch protection ruleset with status checks and review requirements
    - Follow the interactive prompts to select checks and review count
-   - **IMPORTANT**: Since workflows were just changed from inline to reusable callers in step 5, the check names reported by `--list-checks` will be the OLD names (e.g., `build (21)`, `sonar-build`). The reusable workflow produces PREFIXED names: `build / build (21)`, `build / build (25)`, `build / sonar-build`. Use the prefixed names to avoid the PR being unmergeable in step 10.
+   - **IMPORTANT**: Since workflows were just changed from inline to reusable callers in step 6, the check names reported by `--list-checks` will be the OLD names (e.g., `build (21)`, `sonar-build`). The reusable workflow produces PREFIXED names: `build / build (21)`, `build / build (25)`, `build / sonar-build`. Use the prefixed names to avoid the PR being unmergeable in step 11.
 
-7. **Commit and Push**
+8. **Commit and Push**
    - In the target repo at `{local-path}`:
      - Stage all changes: `git -C {local-path} add -A`
      - Commit: `git -C {local-path} commit -m "fix: incorporate cuioss organization settings and workflows"`
      - Push: `git -C {local-path} push -u origin feature/incorporate_cuioss_org`
 
-8. **Create Pull Request**
+9. **Create Pull Request**
    - Create PR using gh CLI (must specify `--head` and `--base` explicitly):
      ```
      gh pr create --repo cuioss/{repo-name} \
@@ -60,23 +67,23 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
      - apply-branch-protection: configured branch protection rulesets"
      ```
 
-9. **Wait for CI**
+10. **Wait for CI**
    - Monitor PR checks: `gh pr checks --repo cuioss/{repo-name} --watch`
    - Report status of each check
 
-10. **Merge PR**
+11. **Merge PR**
     - If all checks pass:
       - AskUserQuestion: "All CI checks passed. Merge the PR?"
       - Options: "Yes, merge" / "No, wait"
     - If confirmed: `gh pr merge --repo cuioss/{repo-name} --squash --delete-branch`
     - If checks fail: report failures and stop for manual intervention
 
-11. **Post-Merge Verification**
+12. **Post-Merge Verification**
     - Wait for main branch CI to trigger
     - Monitor: `gh run list --repo cuioss/{repo-name} --branch main --limit 3`
     - Report final status
 
-12. **Update Consumers List**
+13. **Update Consumers List**
     - In the cuioss-organization repo, update `.github/project.yml`:
       - Check if `{repo-name}` is already in the `consumers` list
       - If not present, add it to the `consumers` list
@@ -89,7 +96,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
       - Merge: `gh pr merge --repo cuioss/cuioss-organization --squash --delete-branch`
       - Switch back: `git checkout main && git pull`
 
-13. **Scorecard Analysis**
+14. **Scorecard Analysis**
     - Wait for the Scorecard workflow to complete on main (triggered by the merge push)
     - If scorecards didn't trigger automatically, note that it runs on schedule or `push` to main
     - Fetch all open code-scanning alerts:
@@ -128,7 +135,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
     - If any alerts are classified as **Fixed**, create a follow-up fix branch, apply changes, create PR, wait for CI, and merge
     - Report the final table to the user
 
-14. **SonarCloud Analysis**
+15. **SonarCloud Analysis**
     - Determine the SonarCloud project key (typically `cuioss_{repo-name}` with hyphens preserved, e.g., `cuioss_cui-java-module-template`)
     - **A. Clean up stale SARIF analyses**:
       - Fetch all code-scanning analyses for the SonarCloud tool:
@@ -170,7 +177,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
     - If any hotspots are classified as **Fixed**, create a follow-up fix branch, apply changes, create PR, wait for CI, and merge
     - Report the final table to the user
 
-15. **CodeQL Cleanup**
+16. **CodeQL Cleanup**
     - Check for stale CodeQL analyses from previous default setup or manual configurations:
       ```
       gh api "repos/cuioss/{repo-name}/code-scanning/analyses?tool_name=CodeQL&per_page=100" \
@@ -188,7 +195,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
       - Report how many were cleaned up
     - If no CodeQL analyses exist, skip this step
 
-16. **Ghost Workflow Cleanup**
+17. **Ghost Workflow Cleanup**
     - Check for ghost workflow entries from renamed or deleted workflow files:
       ```
       gh api "repos/cuioss/{repo-name}/actions/workflows" \

--- a/repo-settings/config.json
+++ b/repo-settings/config.json
@@ -14,6 +14,12 @@
     "secret_scanning": true,
     "secret_scanning_push_protection": true
   },
+  "homepage": {
+    "$comment": "Sidebar 'Include in home page' toggles. No API exists to apply these — advisory only.",
+    "include_packages": false,
+    "include_releases": true,
+    "include_environments": false
+  },
   "merge": {
     "allow_squash_merge": true,
     "allow_merge_commit": true,


### PR DESCRIPTION
## Summary
- Add advisory sidebar detection (Packages, Environments) to `setup-repo-settings.py` via HTML scraping
- Add `homepage` section to `config.json` documenting desired sidebar state
- Integrate warnings into `--diff` and `--apply` modes (advisory only, does not fail verification)
- Update `apply-repo-settings.md` and `setup-consumer-repo.md` commands with sidebar check steps
- Add 13 unit tests covering sidebar detection, warnings, and config schema

## Context
GitHub has no public API for the "Include in home page" sidebar toggles ([gh CLI #8755](https://github.com/cli/cli/issues/8755)). This adds detection and reporting so users are informed about repos with unwanted sidebar sections and given direct links for manual fixing.

## Test plan
- [x] `./pw verify` passes (117 tests, mypy, ruff)
- [ ] Run `./repo-settings/setup-repo-settings.py --repo cui-http --diff` and verify `homepage` section appears
- [ ] Run `./repo-settings/setup-repo-settings.py --repo cui-http --apply` and verify sidebar warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)