### PR TITLE
chore: enable auto-merge and replace polling with gh pr merge --auto

### DIFF
--- a/.github/actions/read-project-config/action.yml
+++ b/.github/actions/read-project-config/action.yml
@@ -81,10 +81,6 @@ outputs:
   auto-merge-build-versions:
     description: 'Auto-merge consumer repo workflow update PRs when CI passes'
     value: ${{ steps.config.outputs.auto-merge-build-versions }}
-  auto-merge-build-timeout:
-    description: 'Timeout in seconds for waiting on CI checks before auto-merge'
-    value: ${{ steps.config.outputs.auto-merge-build-timeout }}
-
   # Consumers
   consumers:
     description: 'Space-separated list of consumer repositories'

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -56,7 +56,6 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["pyprojectx", "verify-command"], "pyprojectx-verify-command", "./pw verify", None),
     # github-automation section
     (["github-automation", "auto-merge-build-versions"], "auto-merge-build-versions", True, None),
-    (["github-automation", "auto-merge-build-timeout"], "auto-merge-build-timeout", 300, None),
     # consumers list (special case: transform list to space-separated string)
     (["consumers"], "consumers", [], lambda x: " ".join(x) if isinstance(x, list) else ""),
 ]
@@ -184,7 +183,7 @@ def print_config_summary(outputs: dict[str, str], config_found: bool, config_pat
         "Pages": ["pages-reference", "deploy-site"],
         "Pyprojectx": ["pyprojectx-python-version", "pyprojectx-cache-dependency-glob",
                        "pyprojectx-upload-artifacts-on-failure", "pyprojectx-verify-command"],
-        "GitHub Automation": ["auto-merge-build-versions", "auto-merge-build-timeout"],
+        "GitHub Automation": ["auto-merge-build-versions"],
         "Other": ["consumers"],
     }
 

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -154,13 +154,6 @@
           "description": "Auto-merge workflow update PRs when CI checks pass",
           "default": true
         },
-        "auto-merge-build-timeout": {
-          "type": "integer",
-          "description": "Timeout in seconds for waiting on CI checks before auto-merge",
-          "default": 300,
-          "minimum": 30,
-          "maximum": 1800
-        }
       },
       "additionalProperties": false
     },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
             ```
 
       - name: Update consumer repos
+        id: update-consumers
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
@@ -112,6 +113,7 @@ jobs:
 
           # Collect results for summary
           RESULTS_FILE=$(mktemp)
+          echo "RESULTS_FILE=$RESULTS_FILE" >> "$GITHUB_OUTPUT"
           echo "[]" > "$RESULTS_FILE"
 
           for REPO in $CONSUMERS; do
@@ -131,7 +133,7 @@ jobs:
             fi
           done
 
-          # Build release summary
+          # Build initial release summary
           {
             echo "## Release v${VERSION} Summary"
             echo ""
@@ -146,8 +148,8 @@ jobs:
               echo "|---|---|---|"
 
               jq -r '.[] |
-                if .status == "pr_created_and_merged" then
-                  "| " + .repo + " | :white_check_mark: Merged | [PR](" + (.pr_url // "-") + ") |"
+                if .status == "pr_auto_merge_enabled" then
+                  "| " + .repo + " | :hourglass: Auto-merge enabled | [PR](" + (.pr_url // "-") + ") |"
                 elif .status == "pr_created" then
                   "| " + .repo + " | :arrow_right: PR Created | [PR](" + (.pr_url // "-") + ") |"
                 elif .status == "no_changes" then
@@ -158,4 +160,16 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          rm -f "$RESULTS_FILE"
+      - name: Verify consumer PR merges
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        run: |
+          RESULTS_FILE="${{ steps.update-consumers.outputs.RESULTS_FILE }}"
+          if [ -n "$RESULTS_FILE" ] && [ -f "$RESULTS_FILE" ]; then
+            python3 "$GITHUB_WORKSPACE/workflow-scripts/verify-consumer-prs.py" \
+              --results-file "$RESULTS_FILE" \
+              --timeout 300
+            rm -f "$RESULTS_FILE"
+          else
+            echo "No results file found, skipping verification"
+          fi

--- a/build.py
+++ b/build.py
@@ -23,6 +23,7 @@ MODULES = {
         ".github/actions/read-project-config/read-config.py",
         "workflow-scripts/update-workflow-references.py",
         "workflow-scripts/update-consumer-repo.py",
+        "workflow-scripts/verify-consumer-prs.py",
     ],
     "repo-admin": [
         "repo-settings/setup-repo-settings.py",
@@ -35,6 +36,7 @@ ALL_SOURCES = [
     ".github/actions/read-project-config/read-config.py",
     "workflow-scripts/update-workflow-references.py",
     "workflow-scripts/update-consumer-repo.py",
+    "workflow-scripts/verify-consumer-prs.py",
     "repo-settings/setup-repo-settings.py",
     "branch-protection/setup-branch-protection.py",
 ]

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -118,7 +118,6 @@ jobs:
 |Field |Type |Default |Description
 
 |`github-automation.auto-merge-build-versions` |boolean |`true` |Auto-merge workflow update PRs when CI checks pass
-|`github-automation.auto-merge-build-timeout` |integer |`300` |Timeout in seconds for waiting on CI checks (30-1800)
 |===
 
 ==== Pyprojectx Section
@@ -169,7 +168,6 @@ pages:
 # GitHub Automation (controls auto-merge of workflow update PRs)
 github-automation:
   auto-merge-build-versions: true
-  auto-merge-build-timeout: 300
 ----
 
 == Fallback Behavior

--- a/repo-settings/config.json
+++ b/repo-settings/config.json
@@ -25,7 +25,7 @@
     "allow_merge_commit": true,
     "allow_rebase_merge": true,
     "delete_branch_on_merge": true,
-    "allow_auto_merge": false,
+    "allow_auto_merge": true,
     "squash_merge_commit_title": "PR_TITLE",
     "squash_merge_commit_message": "PR_BODY"
   },

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -208,7 +208,7 @@ class TestGitHubAutomationSection:
         result = run_script(SCRIPT_PATH, "--config", str(temp_dir / "nonexistent.yml"))
         assert result.returncode == 0
         assert "auto-merge-build-versions=true" in result.stdout
-        assert "auto-merge-build-timeout=300" in result.stdout
+        assert "auto-merge-build-timeout" not in result.stdout
 
     def test_auto_merge_disabled(self, temp_dir):
         """Should read auto-merge-build-versions as false."""
@@ -218,25 +218,13 @@ class TestGitHubAutomationSection:
         assert result.returncode == 0
         assert "auto-merge-build-versions=false" in result.stdout
 
-    def test_custom_timeout(self, temp_dir):
-        """Should read custom auto-merge-build-timeout."""
+    def test_auto_merge_enabled(self, temp_dir):
+        """Should read auto-merge-build-versions as true."""
         config = temp_dir / "project.yml"
-        config.write_text("github-automation:\n  auto-merge-build-timeout: 300")
-        result = run_script(SCRIPT_PATH, "--config", str(config))
-        assert result.returncode == 0
-        assert "auto-merge-build-timeout=300" in result.stdout
-
-    def test_combined_settings(self, temp_dir):
-        """Should read both github-automation settings together."""
-        config = temp_dir / "project.yml"
-        config.write_text("""github-automation:
-  auto-merge-build-versions: true
-  auto-merge-build-timeout: 120
-""")
+        config.write_text("github-automation:\n  auto-merge-build-versions: true")
         result = run_script(SCRIPT_PATH, "--config", str(config))
         assert result.returncode == 0
         assert "auto-merge-build-versions=true" in result.stdout
-        assert "auto-merge-build-timeout=120" in result.stdout
 
 
 class TestEdgeCases:

--- a/test/workflow/test_update_consumer_repo.py
+++ b/test/workflow/test_update_consumer_repo.py
@@ -90,7 +90,7 @@ class TestAutoMergeConfig:
         mod = _load_module()
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is True
-        assert config["timeout"] == 300
+        assert "timeout" not in config
 
     def test_no_github_automation_section(self, temp_dir):
         """Should return defaults when github-automation section is missing."""
@@ -100,7 +100,7 @@ class TestAutoMergeConfig:
         (github_dir / "project.yml").write_text("name: test-repo\n")
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is True
-        assert config["timeout"] == 300
+        assert "timeout" not in config
 
     def test_auto_merge_disabled(self, temp_dir):
         """Should read disabled auto-merge setting."""
@@ -112,33 +112,17 @@ class TestAutoMergeConfig:
         )
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is False
-        assert config["timeout"] == 300
 
-    def test_custom_timeout(self, temp_dir):
-        """Should read custom timeout value."""
+    def test_auto_merge_enabled(self, temp_dir):
+        """Should read enabled auto-merge setting."""
         mod = _load_module()
         github_dir = temp_dir / ".github"
         github_dir.mkdir()
         (github_dir / "project.yml").write_text(
-            "github-automation:\n  auto-merge-build-timeout: 120\n"
+            "github-automation:\n  auto-merge-build-versions: true\n"
         )
         config = mod.read_auto_merge_config(temp_dir)
         assert config["enabled"] is True
-        assert config["timeout"] == 120
-
-    def test_both_settings(self, temp_dir):
-        """Should read both settings correctly."""
-        mod = _load_module()
-        github_dir = temp_dir / ".github"
-        github_dir.mkdir()
-        (github_dir / "project.yml").write_text(
-            "github-automation:\n"
-            "  auto-merge-build-versions: true\n"
-            "  auto-merge-build-timeout: 300\n"
-        )
-        config = mod.read_auto_merge_config(temp_dir)
-        assert config["enabled"] is True
-        assert config["timeout"] == 300
 
     def test_invalid_yaml(self, temp_dir):
         """Should return defaults on invalid YAML."""
@@ -149,4 +133,4 @@ class TestAutoMergeConfig:
         config = mod.read_auto_merge_config(temp_dir)
         # Should fall back to defaults on parse error
         assert config["enabled"] is True
-        assert config["timeout"] == 300
+        assert "timeout" not in config

--- a/test/workflow/test_verify_consumer_prs.py
+++ b/test/workflow/test_verify_consumer_prs.py
@@ -1,0 +1,63 @@
+"""Tests for verify-consumer-prs.py argument validation."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# Add parent to path to access conftest
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from conftest import PROJECT_ROOT, run_script
+
+SCRIPT_PATH = PROJECT_ROOT / "workflow-scripts/verify-consumer-prs.py"
+
+
+def _load_module():
+    """Load verify-consumer-prs.py as a module for unit testing."""
+    spec = importlib.util.spec_from_file_location("verify_consumer_prs", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestArgumentValidation:
+    """Test command line argument validation."""
+
+    def test_requires_results_file(self):
+        """Should fail without --results-file argument."""
+        result = run_script(SCRIPT_PATH)
+        assert result.returncode != 0
+        assert "required" in result.stderr.lower() or "--results-file" in result.stderr
+
+    def test_rejects_missing_file(self):
+        """Should fail when results file does not exist."""
+        result = run_script(SCRIPT_PATH, "--results-file", "/nonexistent/file.json")
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower()
+
+
+class TestVerifyPrs:
+    """Test verify_prs logic with mock data."""
+
+    def test_empty_results(self, temp_dir):
+        """Should handle empty results gracefully."""
+        mod = _load_module()
+        results_file = temp_dir / "results.json"
+        results_file.write_text("[]")
+        final = mod.verify_prs(str(results_file), timeout=10)
+        assert final == []
+
+    def test_no_auto_merge_prs(self, temp_dir):
+        """Should skip PRs that don't have auto-merge enabled."""
+        mod = _load_module()
+        results_file = temp_dir / "results.json"
+        results_file.write_text(
+            json.dumps(
+                [
+                    {"repo": "test-repo", "status": "pr_created", "pr_url": "https://example.com/pr/1"},
+                    {"repo": "test-repo-2", "status": "no_changes", "pr_url": None},
+                ]
+            )
+        )
+        final = mod.verify_prs(str(results_file), timeout=10)
+        assert final == []

--- a/workflow-scripts/verify-consumer-prs.py
+++ b/workflow-scripts/verify-consumer-prs.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Verify auto-merge status of consumer repo PRs after batch creation.
+
+After all consumer PRs are created with `gh pr merge --auto` enabled,
+this script polls them in batch and reports final status.
+
+Usage:
+    ./verify-consumer-prs.py --results-file results.json --timeout 300
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def run_gh(args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run gh CLI command."""
+    return subprocess.run(
+        ["gh"] + args, capture_output=True, text=True, check=check
+    )
+
+
+def write_summary(text: str) -> None:
+    """Append markdown text to GitHub Actions step summary."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(text + "\n")
+
+
+def check_pr_status(pr_url: str) -> dict:
+    """Check current status of a PR.
+
+    Returns dict with:
+        state: str (MERGED, OPEN, CLOSED)
+        merged: bool
+        checks_passed: bool | None
+    """
+    result = run_gh(
+        [
+            "pr",
+            "view",
+            pr_url,
+            "--json",
+            "state,mergedAt,statusCheckRollup",
+        ],
+        check=False,
+    )
+
+    if result.returncode != 0:
+        return {"state": "UNKNOWN", "merged": False, "checks_passed": None}
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"state": "UNKNOWN", "merged": False, "checks_passed": None}
+
+    state = data.get("state", "UNKNOWN")
+    merged = bool(data.get("mergedAt"))
+
+    # Evaluate check status
+    checks = data.get("statusCheckRollup", []) or []
+    if not checks:
+        checks_passed = None
+    else:
+        failed = any(
+            c.get("conclusion") in ("FAILURE", "CANCELLED", "TIMED_OUT")
+            for c in checks
+        )
+        pending = any(c.get("status") in ("QUEUED", "IN_PROGRESS", "PENDING") for c in checks)
+        if failed:
+            checks_passed = False
+        elif pending:
+            checks_passed = None
+        else:
+            checks_passed = True
+
+    return {"state": state, "merged": merged, "checks_passed": checks_passed}
+
+
+def verify_prs(results_file: str, timeout: int, poll_interval: int = 30) -> list[dict]:
+    """Poll all PRs until resolved or timeout.
+
+    Args:
+        results_file: Path to JSON file with PR results from update-consumer-repo.
+        timeout: Maximum seconds to wait.
+        poll_interval: Seconds between poll rounds.
+
+    Returns:
+        List of dicts with repo, pr_url, and final_status.
+    """
+    with open(results_file, encoding="utf-8") as f:
+        results = json.loads(f.read())
+
+    # Filter to only PRs that have auto-merge enabled
+    prs = [
+        r
+        for r in results
+        if r.get("status") == "pr_auto_merge_enabled" and r.get("pr_url")
+    ]
+
+    if not prs:
+        print("No PRs with auto-merge enabled to verify.")
+        return []
+
+    print(f"Verifying {len(prs)} PR(s) with timeout {timeout}s...")
+    elapsed = 0
+    final_results = []
+
+    while elapsed < timeout and prs:
+        remaining = []
+        for pr in prs:
+            status = check_pr_status(pr["pr_url"])
+
+            if status["merged"]:
+                final_results.append(
+                    {"repo": pr["repo"], "pr_url": pr["pr_url"], "final_status": "merged"}
+                )
+                print(f"  {pr['repo']}: merged")
+            elif status["checks_passed"] is False:
+                final_results.append(
+                    {"repo": pr["repo"], "pr_url": pr["pr_url"], "final_status": "failed"}
+                )
+                print(f"  {pr['repo']}: checks failed")
+            elif status["state"] == "CLOSED":
+                final_results.append(
+                    {"repo": pr["repo"], "pr_url": pr["pr_url"], "final_status": "closed"}
+                )
+                print(f"  {pr['repo']}: closed")
+            else:
+                remaining.append(pr)
+                print(f"  {pr['repo']}: pending ({elapsed}s/{timeout}s)")
+
+        prs = remaining
+        if prs and elapsed < timeout:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+    # Any remaining PRs are still pending
+    for pr in prs:
+        final_results.append(
+            {"repo": pr["repo"], "pr_url": pr["pr_url"], "final_status": "pending"}
+        )
+
+    return final_results
+
+
+def print_summary(final_results: list[dict]) -> None:
+    """Print summary table to GitHub Actions step summary."""
+    if not final_results:
+        return
+
+    status_icons = {
+        "merged": ":white_check_mark: Merged",
+        "pending": ":hourglass: Auto-merge pending",
+        "failed": ":x: Failed",
+        "closed": ":x: Closed",
+    }
+
+    lines = [
+        "### Consumer PR Verification",
+        "",
+        "| Repository | Status | PR |",
+        "|---|---|---|",
+    ]
+
+    for r in final_results:
+        icon = status_icons.get(r["final_status"], r["final_status"])
+        pr_link = f"[PR]({r['pr_url']})" if r.get("pr_url") else "-"
+        lines.append(f"| {r['repo']} | {icon} | {pr_link} |")
+
+    summary = "\n".join(lines)
+    print(summary)
+    write_summary(summary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify auto-merge status of consumer repo PRs"
+    )
+    parser.add_argument(
+        "--results-file",
+        required=True,
+        help="Path to JSON results file from update-consumer-repo runs",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Maximum seconds to wait for PRs to merge (default: 300)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=30,
+        help="Seconds between poll rounds (default: 30)",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.results_file):
+        print(f"Error: results file not found: {args.results_file}", file=sys.stderr)
+        return 1
+
+    final_results = verify_prs(args.results_file, args.timeout, args.poll_interval)
+    print_summary(final_results)
+
+    # Return non-zero if any PR failed
+    failed = any(r["final_status"] == "failed" for r in final_results)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Enable native auto-merge** on all consumer repos by setting `allow_auto_merge: true` in `repo-settings/config.json`
- **Replace 90-line polling** `auto_merge_pr()` in `update-consumer-repo.py` with a simple `gh pr merge --auto --squash --delete-branch` call that returns immediately
- **Add batch verification script** (`verify-consumer-prs.py`) that polls all PRs after creation and reports final merge status
- **Remove `auto-merge-build-timeout`** from schema, action outputs, config reader, docs, and tests — no longer needed since GitHub handles the wait
- **Update release workflow** to two phases: create PRs + enable auto-merge, then batch verify

## Test plan

- [x] `./pw verify` — all 119 tests pass, mypy clean, ruff clean
- [ ] After merging, apply repo settings to consumer repos: `./setup-repo-settings.py --repo <repo> --apply`
- [ ] Verify `gh api repos/cuioss/<repo> --jq .allow_auto_merge` returns `true`
- [ ] On next release, verify consumer PRs get auto-merge enabled and eventually merge

## Follow-up

- Remove `auto-merge-build-timeout` from `.github/project.yml` in all 8 consumer repos (separate PRs)
- Dependabot auto-merge workflow (deferred, standalone addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)