### PR TITLE
chore: update Git Workflow to use auto-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
 4. Create a PR: `gh pr create --repo cuioss/<repo> --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI: `gh pr checks --repo cuioss/<repo> --watch`
-6. Merge when checks pass: `gh pr merge --repo cuioss/<repo> --squash --delete-branch`
+5. Enable auto-merge: `gh pr merge --repo cuioss/<repo> --auto --squash --delete-branch`
+6. Wait for merge (check every ~60s): `while gh pr view --repo cuioss/<repo> --json state -q '.state' | grep -q OPEN; do sleep 60; done`
 7. Return to main: `git checkout main && git pull`
 
 This applies to both this repository and all consumer repositories.


### PR DESCRIPTION
## Summary

- Update Git Workflow section in CLAUDE.md to use `gh pr merge --auto --squash --delete-branch` instead of manual `gh pr checks --watch` + `gh pr merge`
- Add polling loop that checks merge state every ~60s

## Related

- Follows from #58 which enabled auto-merge on all repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)