### PR TITLE
chore: update slash commands to use auto-merge workflow

### DIFF
--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -83,9 +83,8 @@ Synchronize GitHub Actions workflow files from this organization repository to a
      - Stage and commit: `git -C {local-path} add .github/workflows/ .github/project.yml && git -C {local-path} commit -m "chore: update GitHub Actions workflows from cuioss-organization"`
      - Push: `git -C {local-path} push -u origin chore/update-github-actions`
      - Create PR: `gh pr create --repo cuioss/{repo-name} --head chore/update-github-actions --base main --title "chore: update GitHub Actions workflows" --body "..."`
-     - Wait for CI: `gh pr checks --repo cuioss/{repo-name} --watch`
-     - AskUserQuestion: "Merge the PR?"
-     - If yes: `gh pr merge --repo cuioss/{repo-name} --squash --delete-branch`
+     - Enable auto-merge: `gh pr merge --repo cuioss/{repo-name} --auto --squash --delete-branch`
+     - Wait for merge (check every ~60s): `while gh pr view --repo cuioss/{repo-name} --json state -q '.state' | grep -q OPEN; do sleep 60; done`
      - Return to main: `git -C {local-path} checkout main && git -C {local-path} pull`
 
 10. **Update Consumers List**
@@ -95,7 +94,7 @@ Synchronize GitHub Actions workflow files from this organization repository to a
     - Create a branch: `git checkout -b chore/add-{repo-name}-consumer`
     - Commit the update: `git add .github/project.yml && git commit -m "chore: add {repo-name} to consumers list"`
     - Push: `git push -u origin chore/add-{repo-name}-consumer`
-    - Create PR, wait for CI, merge, then switch back to main
+    - Create PR, enable auto-merge (`gh pr merge --auto --squash --delete-branch`), wait for merge, then switch back to main
 
 ## Arguments
 

--- a/.claude/commands/verify-org-integration.md
+++ b/.claude/commands/verify-org-integration.md
@@ -87,9 +87,8 @@ Identifies and removes:
      - Stage and commit: `git -C ~/git/{repo-name} add -A && git -C ~/git/{repo-name} commit -m "chore: align with org-level community health files"`
      - Push: `git -C ~/git/{repo-name} push -u origin chore/align-org-health-files`
      - Create PR: `gh pr create --repo cuioss/{repo-name} --head chore/align-org-health-files --base main --title "chore: align with org-level community health files" --body "..."`
-     - Wait for CI: `gh pr checks --repo cuioss/{repo-name} --watch`
-     - AskUserQuestion: "Merge the PR?"
-     - If yes: `gh pr merge --repo cuioss/{repo-name} --squash --delete-branch`
+     - Enable auto-merge: `gh pr merge --repo cuioss/{repo-name} --auto --squash --delete-branch`
+     - Wait for merge (check every ~60s): `while gh pr view --repo cuioss/{repo-name} --json state -q '.state' | grep -q OPEN; do sleep 60; done`
      - Return to main: `git -C ~/git/{repo-name} checkout main && git -C ~/git/{repo-name} pull`
 
 10. **Report Summary**


### PR DESCRIPTION
## Summary
- Updated `.claude/commands/setup-consumer-repo.md` to use `gh pr merge --auto --squash --delete-branch` instead of polling
- Updated `.claude/commands/verify-org-integration.md` to use auto-merge
- Updated `.claude/commands/update-github-actions.md` to use auto-merge
- Removed references to deprecated `auto-merge-build-timeout` configuration

These slash commands are the templates that generate Git Workflow sections in consumer repos. They now match the auto-merge pattern implemented in PR #58.