### PR TITLE
chore: add nifi-extensions to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -16,3 +16,4 @@ consumers:
   - cui-jsf-test-basic
   - cui-open-rewrite
   - cui-http
+  - nifi-extensions


### PR DESCRIPTION
Add nifi-extensions to consumers list after workflow migration