### PR TITLE
chore: add cui-test-keycloak-integration to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -17,3 +17,4 @@ consumers:
   - cui-open-rewrite
   - cui-http
   - nifi-extensions
+  - cui-test-keycloak-integration


### PR DESCRIPTION
Add cui-test-keycloak-integration to consumers list after workflow migration