### PR TITLE
chore: add cui-core-ui-model to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -18,3 +18,4 @@ consumers:
   - cui-http
   - nifi-extensions
   - cui-test-keycloak-integration
+  - cui-core-ui-model


### PR DESCRIPTION
Add cui-core-ui-model to consumers list after workflow migration