### PR TITLE
chore: add cui-test-mockwebserver-junit5 to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -19,3 +19,4 @@ consumers:
   - nifi-extensions
   - cui-test-keycloak-integration
   - cui-core-ui-model
+  - cui-test-mockwebserver-junit5


### PR DESCRIPTION
Add cui-test-mockwebserver-junit5 to consumers list after workflow migration