### PR TITLE
chore: add cui-portal-core to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -21,3 +21,4 @@ consumers:
   - cui-core-ui-model
   - cui-test-mockwebserver-junit5
   - cui-portal-ui
+  - cui-portal-core


### PR DESCRIPTION
Add cui-portal-core to consumers list after workflow migration