### PR TITLE
feat: add reusable npm build and publish workflows

### DIFF
--- a/.github/actions/read-project-config/action.yml
+++ b/.github/actions/read-project-config/action.yml
@@ -33,6 +33,14 @@ outputs:
     description: 'Enable npm package caching'
     value: ${{ steps.config.outputs.npm-cache }}
 
+  # npm Build Section
+  npm-node-version:
+    description: 'Node.js version for npm builds'
+    value: ${{ steps.config.outputs.npm-node-version }}
+  npm-registry-url:
+    description: 'npm registry URL'
+    value: ${{ steps.config.outputs.npm-registry-url }}
+
   # Sonar Section
   sonar-enabled:
     description: 'Enable SonarCloud analysis'

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -49,6 +49,9 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     # pages section
     (["pages", "reference"], "pages-reference", "", None),
     (["pages", "deploy-at-release"], "deploy-site", True, None),
+    # npm-build section
+    (["npm-build", "node-version"], "npm-node-version", "22", None),
+    (["npm-build", "registry-url"], "npm-registry-url", "https://registry.npmjs.org", None),
     # pyprojectx section
     (["pyprojectx", "python-version"], "pyprojectx-python-version", "", None),
     (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "uv.lock", None),
@@ -178,6 +181,7 @@ def print_config_summary(outputs: dict[str, str], config_found: bool, config_pat
     sections = {
         "Maven Build": ["java-versions", "java-version", "enable-snapshot-deploy",
                        "maven-profiles-snapshot", "maven-profiles-release", "npm-cache"],
+        "npm Build": ["npm-node-version", "npm-registry-url"],
         "Sonar": ["sonar-enabled", "sonar-skip-on-dependabot", "sonar-project-key"],
         "Release": ["current-version", "next-version", "create-github-release"],
         "Pages": ["pages-reference", "deploy-site"],

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -52,6 +52,25 @@
       },
       "additionalProperties": false
     },
+    "npm-build": {
+      "type": "object",
+      "description": "npm build configuration for Node.js projects",
+      "properties": {
+        "node-version": {
+          "type": "string",
+          "description": "Node.js version for builds",
+          "default": "22",
+          "examples": ["20", "22"]
+        },
+        "registry-url": {
+          "type": "string",
+          "description": "npm registry URL for publishing",
+          "default": "https://registry.npmjs.org",
+          "examples": ["https://registry.npmjs.org", "https://npm.pkg.github.com"]
+        }
+      },
+      "additionalProperties": false
+    },
     "sonar": {
       "type": "object",
       "description": "SonarCloud configuration",

--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -1,0 +1,123 @@
+name: npm Build (Reusable)
+# Reusable workflow for Node.js projects using npm
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '22'
+      enable-sonar:
+        description: 'Enable SonarCloud analysis'
+        required: false
+        type: boolean
+        default: true
+      skip-sonar-on-dependabot:
+        description: 'Skip Sonar analysis for Dependabot PRs'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      SONAR_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Read project.yml configuration to use as defaults
+  config:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      npm-node-version: ${{ steps.config.outputs.npm-node-version }}
+      npm-registry-url: ${{ steps.config.outputs.npm-registry-url }}
+      sonar-enabled: ${{ steps.config.outputs.sonar-enabled }}
+      sonar-skip-on-dependabot: ${{ steps.config.outputs.sonar-skip-on-dependabot }}
+      sonar-project-key: ${{ steps.config.outputs.sonar-project-key }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/project.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Read project.yml configuration
+        id: config
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@v0.2.5
+
+  build:
+    needs: config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js ${{ needs.config.outputs.npm-node-version || inputs.node-version }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ needs.config.outputs.npm-node-version || inputs.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Format check
+        run: npm run format:check --if-present
+
+      - name: Test
+        run: npm test
+
+  sonar-build:
+    needs: [config, build]
+    if: ${{ (needs.config.outputs.sonar-enabled != 'false' && inputs.enable-sonar) && !((needs.config.outputs.sonar-skip-on-dependabot == 'true' || inputs.skip-sonar-on-dependabot) && github.actor == 'dependabot[bot]') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js ${{ needs.config.outputs.npm-node-version || inputs.node-version }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ needs.config.outputs.npm-node-version || inputs.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Test with coverage
+        run: npm test
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -1,0 +1,107 @@
+name: npm Publish (Reusable)
+# Reusable workflow for publishing npm packages with OIDC trusted publishing
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '22'
+    secrets:
+      RELEASE_APP_ID:
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    environment: npm-publish
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - name: Generate Release Token
+        id: release-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          owner: cuioss
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Read project.yml configuration
+        id: config
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@v0.2.5
+
+      - name: Set up Node.js ${{ steps.config.outputs.npm-node-version || inputs.node-version }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.config.outputs.npm-node-version || inputs.node-version }}
+          registry-url: ${{ steps.config.outputs.npm-registry-url || 'https://registry.npmjs.org' }}
+          cache: 'npm'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Stamp version ${{ steps.config.outputs.current-version }}
+        run: npm version ${{ steps.config.outputs.current-version }} --no-git-tag-version --allow-same-version
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm (OIDC trusted publishing)
+        run: npm publish --provenance --access public --ignore-scripts
+
+      - name: Configure Git author
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "cuioss-release-bot"
+
+      - name: Commit version stamp and create tag
+        run: |
+          git add package.json package-lock.json
+          git diff --cached --quiet || git commit -m "release: v${{ steps.config.outputs.current-version }}"
+          git tag -a "v${{ steps.config.outputs.current-version }}" -m "Release ${{ steps.config.outputs.current-version }}"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
+        with:
+          github_token: ${{ steps.release-token.outputs.token }}
+          branch: ${{ github.ref_name }}
+
+      - name: Push tag v${{ steps.config.outputs.current-version }}
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
+        with:
+          github_token: ${{ steps.release-token.outputs.token }}
+          branch: ${{ github.ref_name }}
+          tags: true
+
+      - name: Create GitHub Release
+        if: ${{ steps.config.outputs.create-github-release == 'true' }}
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          tag_name: v${{ steps.config.outputs.current-version }}
+          name: v${{ steps.config.outputs.current-version }}
+          generate_release_notes: true
+          make_latest: true

--- a/docs/Secrets.adoc
+++ b/docs/Secrets.adoc
@@ -57,6 +57,17 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 * **Security** - Fewer copies of sensitive credentials
 * **SonarCloud** - Organization uses a single SonarCloud token for all projects
 
+== npm Publishing (No Token Required)
+
+The `reusable-npm-publish.yml` workflow uses **OIDC Trusted Publishing** instead of a stored npm token.
+GitHub's OIDC provider authenticates directly with the npm registry during publish.
+
+* No `NPM_TOKEN` org secret is needed
+* Requires `id-token: write` permission in the caller workflow
+* Requires an `npm-publish` GitHub Environment configured in the consumer repo
+* The npm trusted publisher must be configured on npmjs.com (repository, environment, workflow filename)
+* Uses existing `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` for git tag/push operations only
+
 == Migration Checklist
 
 When migrating repos to the organization:

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -79,6 +79,14 @@ NOTE: We intentionally do not use workflow-level `concurrency` with `cancel-in-p
 |`reusable-pyprojectx-verify.yml`
 |Python/pyprojectx build verification
 |~45 → ~10
+
+|`reusable-npm-build.yml`
+|Node.js npm build, lint, test, Sonar analysis
+|~80 → ~12
+
+|`reusable-npm-publish.yml`
+|Publish to npm with OIDC trusted publishing
+|~80 → ~12
 |===
 
 == Configuration via project.yml
@@ -421,6 +429,126 @@ jobs:
 
 This workflow does not require any secrets.
 
+== npm Build
+
+=== Basic Usage
+
+[source,yaml]
+----
+# Configuration is read from .github/project.yml - no inputs needed!
+name: npm Build
+
+on:
+  push:
+    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    # Run on push, OR on pull_request only if from a fork
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@main
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+----
+
+=== Inputs (Optional - override project.yml)
+
+[cols="1,1,1,2"]
+|===
+|Input |Type |Default |Description
+
+|`node-version`
+|string
+|`22`
+|Node.js version
+
+|`enable-sonar`
+|boolean
+|`true`
+|Enable SonarCloud analysis
+
+|`skip-sonar-on-dependabot`
+|boolean
+|`true`
+|Skip Sonar for Dependabot PRs
+|===
+
+=== Required Secrets
+
+[cols="1,2"]
+|===
+|Secret |Required For
+
+|`SONAR_TOKEN`
+|Sonar analysis (optional)
+|===
+
+== npm Publish
+
+=== Basic Usage
+
+[source,yaml]
+----
+# Configuration is read from .github/project.yml - no inputs needed!
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    paths: ['.github/project.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-publish.yml@main
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+----
+
+=== Inputs (Optional - override project.yml)
+
+[cols="1,1,1,2"]
+|===
+|Input |Type |Default |Description
+
+|`node-version`
+|string
+|`22`
+|Node.js version for release
+|===
+
+=== Required Secrets
+
+[cols="1,2"]
+|===
+|Secret |Description
+
+|`RELEASE_APP_ID`
+|cuioss-release-bot App ID
+
+|`RELEASE_APP_PRIVATE_KEY`
+|cuioss-release-bot private key
+|===
+
+=== No npm Token Required
+
+This workflow uses **OIDC Trusted Publishing** — no long-lived npm tokens are stored anywhere.
+GitHub's OIDC provider authenticates directly with npm during the publish step.
+The caller workflow must grant `id-token: write` permission to enable this.
+
 == Examples
 
 See link:workflow-examples/[workflow-examples/] directory for complete caller workflow templates:
@@ -431,6 +559,8 @@ See link:workflow-examples/[workflow-examples/] directory for complete caller wo
 * link:workflow-examples/scorecards-caller.yml[scorecards-caller.yml] - Scorecard analysis
 * link:workflow-examples/dependency-review-caller.yml[dependency-review-caller.yml] - Dependency review
 * link:workflow-examples/pyprojectx-verify-caller.yml[pyprojectx-verify-caller.yml] - Python/pyprojectx verification
+* link:workflow-examples/npm-build-caller.yml[npm-build-caller.yml] - npm build
+* link:workflow-examples/npm-publish-caller.yml[npm-publish-caller.yml] - npm publish (OIDC trusted publishing)
 
 == Migration Guide
 
@@ -483,6 +613,12 @@ All action versions are pinned centrally in this repo:
 
 |`softprops/action-gh-release`
 |v2.5.0
+
+|`actions/setup-node`
+|v6.2.0
+
+|`SonarSource/sonarqube-scan-action`
+|v7.0.0
 |===
 
 To update versions: Edit the reusable workflows here, all repos inherit automatically.

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -112,6 +112,15 @@ jobs:
 |`pages.deploy-at-release` |boolean |`true` |Deploy Maven site to GitHub Pages during release
 |===
 
+==== npm Build Section
+
+|===
+|Field |Type |Default |Description
+
+|`npm-build.node-version` |string |`'22'` |Node.js version for builds
+|`npm-build.registry-url` |string |`'https://registry.npmjs.org'` |npm registry URL for publishing
+|===
+
 ==== GitHub Automation Section
 
 |===

--- a/docs/workflow-examples/npm-build-caller.yml
+++ b/docs/workflow-examples/npm-build-caller.yml
@@ -1,0 +1,22 @@
+# Example: Copy this to your repo as .github/workflows/npm-build.yml
+# Configuration is read from .github/project.yml - no inputs needed!
+name: npm Build
+
+on:
+  push:
+    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    # Run on push events, OR on pull_request only if from a fork
+    # This prevents duplicate runs: push handles internal branches, PR handles forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@main
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/workflow-examples/npm-publish-caller.yml
+++ b/docs/workflow-examples/npm-publish-caller.yml
@@ -1,0 +1,24 @@
+# Example: Copy this to your repo as .github/workflows/release.yml
+# Configuration is read from .github/project.yml - no inputs needed!
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - '.github/project.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-publish.yml@main
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -200,6 +200,45 @@ class TestPyprojectxSection:
         assert "pyprojectx-verify-command=./pw quality-gate" in result.stdout
 
 
+class TestNpmBuildSection:
+    """Test npm-build configuration section."""
+
+    def test_default_npm_values(self, temp_dir):
+        """Should provide default npm-build values when not configured."""
+        result = run_script(SCRIPT_PATH, "--config", str(temp_dir / "nonexistent.yml"))
+        assert result.returncode == 0
+        assert "npm-node-version=22" in result.stdout
+        assert "npm-registry-url=https://registry.npmjs.org" in result.stdout
+
+    def test_reads_npm_node_version(self, temp_dir):
+        """Should read node-version from npm-build section."""
+        config = temp_dir / "project.yml"
+        config.write_text('npm-build:\n  node-version: "20"')
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "npm-node-version=20" in result.stdout
+
+    def test_reads_npm_registry_url(self, temp_dir):
+        """Should read registry-url from npm-build section."""
+        config = temp_dir / "project.yml"
+        config.write_text("npm-build:\n  registry-url: https://npm.pkg.github.com")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "npm-registry-url=https://npm.pkg.github.com" in result.stdout
+
+    def test_reads_full_npm_config(self, temp_dir):
+        """Should read all npm-build settings together."""
+        config = temp_dir / "project.yml"
+        config.write_text("""npm-build:
+  node-version: "20"
+  registry-url: https://npm.pkg.github.com
+""")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "npm-node-version=20" in result.stdout
+        assert "npm-registry-url=https://npm.pkg.github.com" in result.stdout
+
+
 class TestGitHubAutomationSection:
     """Test github-automation configuration section."""
 


### PR DESCRIPTION
## Summary

- Add `reusable-npm-build.yml` — Node.js build workflow with lint, test, and SonarCloud analysis (SHA-pinned actions, harden-runner)
- Add `reusable-npm-publish.yml` — npm publish with OIDC trusted publishing (no npm token needed), provenance, release-bot token for git tag/push
- Extend `read-project-config` with `npm-build` section (`node-version`, `registry-url`) in FIELD_REGISTRY, action.yml outputs, and JSON schema
- Add caller templates (`npm-build-caller.yml`, `npm-publish-caller.yml`)
- Update `Workflows.adoc`, `project-yml-schema.adoc`, and `Secrets.adoc` documentation

## Security

- **OIDC Trusted Publishing**: No npm tokens stored anywhere. `id-token: write` + `npm-publish` GitHub Environment
- **`--provenance`**: SLSA attestation signed via Sigstore
- **`--ignore-scripts`**: Blocks malicious lifecycle scripts on both `npm ci` and `npm publish`
- **SHA-pinned actions**: `actions/setup-node@v6.2.0`, `SonarSource/sonarqube-scan-action@v7.0.0`
- **No new secrets needed**: Reuses `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `SONAR_TOKEN`

## Context

First step toward [cuioss/nifi-extensions#106](https://github.com/cuioss/nifi-extensions/issues/106) — extracting Playwright test artifact infrastructure into `@cuioss/playwright-test-logger` npm package.

## Test plan

- [x] `./pw verify workflow` passes (64 tests, mypy, ruff)
- [ ] CI passes on this PR
- [ ] Validate workflows when used by first npm consumer repo (`playwright-test-logger`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)