### PR TITLE
chore: add playwright-test-logger to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -22,3 +22,4 @@ consumers:
   - cui-test-mockwebserver-junit5
   - cui-portal-ui
   - cui-portal-core
+  - playwright-test-logger


### PR DESCRIPTION
## Summary

- Add `playwright-test-logger` to the consumers list in `project.yml`

Part of the setup for the new `@cuioss/playwright-test-logger` npm package repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)