### PR TITLE
chore: rename playwright-test-logger to playwright-test-artifacts

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -22,4 +22,4 @@ consumers:
   - cui-test-mockwebserver-junit5
   - cui-portal-ui
   - cui-portal-core
-  - playwright-test-logger
+  - playwright-test-artifacts


### PR DESCRIPTION
## Summary

- Rename consumer entry from `playwright-test-logger` to `playwright-test-artifacts` to better reflect the package scope (logs, screenshots, artifact management — not just logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)