### PR TITLE
fix: add explicit SONAR_HOST_URL for SonarCloud scan

### DIFF
--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -130,3 +130,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- SonarScanner CLI 8.x in sonarqube-scan-action v7 fails with `No organization with key 'cuioss'` when loading quality profiles
- Adding explicit `SONAR_HOST_URL: https://sonarcloud.io` may be needed for scanner v8 to properly resolve the organization

## Test plan
- [ ] Verify sonar-build job passes on playwright-test-artifacts after updating caller SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)