### PR TITLE
fix: use SONARCLOUD_URL env var for sonarqube-scan-action v7

### DIFF
--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -130,4 +130,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
+          SONARCLOUD_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- The sonarqube-scan-action v7 source code reads `SONARCLOUD_URL` (not `SONAR_HOST_URL`) to pass `-Dsonar.scanner.sonarcloudUrl` to the scanner CLI 8.x
- Without this, the scanner doesn't know it's targeting SonarCloud and fails loading quality profiles with "No organization with key"
- Replace `SONAR_HOST_URL` with `SONARCLOUD_URL: https://sonarcloud.io`

Found by reading the [action source code](https://github.com/SonarSource/sonarqube-scan-action/blob/a31c9398be7ace6bbfaf30c0bd5d415f843d45e9/src/main/index.js)

## Test plan
- [ ] Verify sonar-build job passes on playwright-test-artifacts after updating caller SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)