### PR TITLE
fix: install SNAPSHOT artifacts before site generation for multi-module projects

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -97,6 +97,8 @@ jobs:
           ./mvnw -B --no-transfer-progress -P${{ steps.config.outputs.maven-profiles-release || inputs.maven-profiles }} release:clean release:prepare \
             -DreleaseVersion=${{ steps.config.outputs.current-version }} \
             -DdevelopmentVersion=${{ steps.config.outputs.next-version }}
+          # Install SNAPSHOT artifacts to local repo for multi-module site generation
+          ./mvnw -B --no-transfer-progress install -DskipTests
           ./mvnw -B --no-transfer-progress -P${{ steps.config.outputs.maven-profiles-release || inputs.maven-profiles }} site:site site:stage
           git checkout ${{ github.ref_name }}
           git rebase release


### PR DESCRIPTION
## Summary

- Fixes #69: Release workflow `site:site site:stage` fails for multi-module projects because inter-module SNAPSHOT dependencies are not in the local Maven repo after `release:prepare`
- Adds `./mvnw install -DskipTests` before site generation to populate the local repo
- Harmless for single-module projects (installs one unused SNAPSHOT jar, a few seconds overhead)

## Test plan

- [ ] After merge, trigger the release workflow on `cui-portal-core` via `workflow_dispatch`
- [ ] Confirm `install -DskipTests` step succeeds
- [ ] Confirm `site:site site:stage` completes without dependency resolution errors
- [ ] Confirm `release:perform` and full release complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)