### PR TITLE
chore: bump version to 0.2.9

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.2.8
+  current-version: 0.2.9
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary

- Bump release version to 0.2.9 to include the multi-module site generation fix from #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)