### PR TITLE
chore: add cui-jsf-components to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -23,3 +23,4 @@ consumers:
   - cui-portal-ui
   - cui-portal-core
   - playwright-test-artifacts
+  - cui-jsf-components


### PR DESCRIPTION
## Summary
- Add cui-jsf-components to consumers list after workflow migration