### PR TITLE
fix: make consumer PR verification non-blocking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify consumer PR merges
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the "Verify consumer PR merges" step in `release.yml`
- The release (tag, GitHub Release, consumer PR creation) is already complete before this step runs, so a downstream CI failure or timeout should not fail the release job
- Failures are still reported in the step summary and visible in the workflow run

Triggered by v0.3.2 release where `cui-portal-core` had a pre-existing Java 25 test failure that blocked auto-merge and caused the release job to fail.

## Test plan

- [x] Verified the step is the last step in the job — no downstream steps depend on it
- [ ] Next release will validate the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)