### PR TITLE
chore: release v0.3.5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.3.4
+  current-version: 0.3.5
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
## Summary

- Bump version to 0.3.5 for release

## Changes in this release

- Redesigned `reusable-maven-integration-tests.yml` with new input interface (#94)
- New `assemble-test-reports` composite action
- Removed `integration-tests` section from `read-project-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)