### PR TITLE
chore: add API-Sheriff to consumers list

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -8,6 +8,7 @@ release:
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)
 consumers:
+  - API-Sheriff
   - cui-core-ui-model
   - cui-http
   - cui-java-module-template


### PR DESCRIPTION
## Summary
- Add API-Sheriff to consumers list after workflow migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)