### PR TITLE
fix: pin Playwright browser install to project-resolved version

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.6.5
+  current-version: 0.6.6
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -214,11 +214,30 @@ jobs:
 
       - name: Install Playwright browsers
         if: ${{ inputs.install-playwright && steps.playwright-cache.outputs.cache-hit != 'true' }}
-        run: npx playwright install
+        env:
+          PW_VERSION: ${{ steps.playwright-version.outputs.version }}
+        run: |
+          # Pin the install to the project's resolved @playwright/test version so the
+          # matching browser revision is downloaded. Bare `npx playwright install`
+          # resolves to the latest Playwright and fetches the wrong browser revision
+          # (see issue #155).
+          if [ -n "$PW_VERSION" ] && [ "$PW_VERSION" != "unknown" ]; then
+            npx playwright@"$PW_VERSION" install
+          else
+            echo "::warning::Could not detect @playwright/test version; falling back to latest Playwright"
+            npx playwright install
+          fi
 
       - name: Install Playwright system dependencies
         if: ${{ inputs.install-playwright }}
-        run: npx playwright install-deps
+        env:
+          PW_VERSION: ${{ steps.playwright-version.outputs.version }}
+        run: |
+          if [ -n "$PW_VERSION" ] && [ "$PW_VERSION" != "unknown" ]; then
+            npx playwright@"$PW_VERSION" install-deps
+          else
+            npx playwright install-deps
+          fi
 
       - name: Validate and run Maven commands
         env:


### PR DESCRIPTION
## Problem

The reusable workflow `.github/workflows/reusable-maven-integration-tests.yml` (with `install-playwright: true`) ran a bare `npx playwright install` **before** the project's dependencies were resolved via `npm ci` (which happens inside the Maven build). Because `@playwright/test` is not yet resolved locally at that point, `npx` pulls the *latest* Playwright and downloads *its* browser revision — not the one the project pins.

Tests then run against the project-pinned `@playwright/test` and fail at browser launch because the matching browser binary was never downloaded:

```
Error: browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/...
```

This deterministically broke every PR in `cuioss/nifi-extensions` after it bumped `@playwright/test` to `1.58.2` (needs `chromium_headless_shell` revision 1208).

## Fix

Pin both the browser install and `install-deps` to the **detected** `@playwright/test` version — already computed in the `Detect Playwright version` step for the cache key — via `npx playwright@<version> install`. This fetches the correct browser revision regardless of npm ci ordering, without the generic reusable workflow needing to know the project's Playwright module path.

Falls back to the previous bare `npx playwright install` (with a warning) when the version cannot be detected.

Fixes #155