### PR TITLE
fix(ci): skip redundant push build when an open PR covers the commit

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -99,14 +99,21 @@ jobs:
           if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          # Push to a non-default branch: skip if an open PR already covers it —
-          # the pull_request run builds the same commit (with PR-scoped Sonar).
-          count="$(gh pr list --head "$REF_NAME" --state open --json number --jq 'length')"
+          # Push to a non-default branch: skip if an open SAME-REPO PR already
+          # covers it — the pull_request run builds the same commit (with PR-scoped
+          # Sonar). Only internal PRs count: a fork PR that happens to reuse this
+          # branch name builds a different repo's commit, so cross-repository PRs
+          # are excluded (gh's --head matches a bare branch name across forks).
+          # Fail open — a transient lookup error runs the build rather than skipping it.
+          if ! count="$(gh pr list --repo "$GH_REPO" --head "$REF_NAME" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)] | length')"; then
+            echo "PR lookup failed for '$REF_NAME' — defaulting to run push build"
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           if [[ "${count:-0}" -gt 0 ]]; then
-            echo "Open PR exists for '$REF_NAME' — skipping push build (the PR run builds this commit)"
+            echo "Open same-repo PR exists for '$REF_NAME' — skipping push build (the PR run builds this commit)"
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
-            echo "No open PR for '$REF_NAME' — running push build"
+            echo "No open same-repo PR for '$REF_NAME' — running push build"
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -69,8 +69,51 @@ permissions:
   contents: read
 
 jobs:
+  # Decide whether this run should proceed. Skips a push-triggered build when an
+  # open PR already covers the same branch — the PR's own run builds that commit
+  # (and produces a Sonar pull-request analysis), so the push build is redundant.
+  # A push to a branch with no open PR still builds (branch analysis + quality),
+  # and the default branch always builds (Sonar baseline + snapshot deploy).
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether to run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # Non-push events (pull_request, workflow_dispatch, …) always run.
+          if [[ "$EVENT_NAME" != "push" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # The default branch always runs (post-merge baseline + snapshot deploy).
+          if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Push to a non-default branch: skip if an open PR already covers it —
+          # the pull_request run builds the same commit (with PR-scoped Sonar).
+          count="$(gh pr list --head "$REF_NAME" --state open --json number --jq 'length')"
+          if [[ "${count:-0}" -gt 0 ]]; then
+            echo "Open PR exists for '$REF_NAME' — skipping push build (the PR run builds this commit)"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open PR for '$REF_NAME' — running push build"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Read project.yml configuration to use as defaults
   config:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -9,48 +9,74 @@ Eliminates copy-paste duplication and centralizes action version management.
 
 == Workflow Triggers and Duplicate Prevention
 
-All cuioss caller workflows use a consistent trigger pattern:
+=== Maven build — gate-based dedup
+
+`reusable-maven-build.yml` runs on every push and every pull request. A `gate`
+job inside the reusable workflow skips a push-triggered build when an open PR
+already covers that commit — the PR's own run builds it (producing a Sonar
+*pull-request* analysis), so the push build would be redundant. A push to a
+branch with **no** open PR still builds (Sonar *branch* analysis + quality), and
+the default branch always builds. The caller therefore needs **no `if:`**; it
+only grants `pull-requests: read` so the gate can read open PRs:
 
 [source,yaml]
 ----
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
 ----
 
-=== Why This Pattern?
+This gives quality feedback on **every** push, a Sonar pull-request analysis
+whenever a PR exists, no push/PR duplicate, and no "stuck PR" when GitHub drops
+a push event. The always-green `conclusion` job is the branch-protection
+required check, so a gate-skipped push run still reports success.
 
-* **`push` to `main`, `feature/*`, `fix/*`, `chore/*`, and `dependabot/**`**: Ensures all commits are verified, including early pushes to feature/fix/chore branches and dependabot updates before a PR is opened.
-* **`pull_request` to `main`**: Verifies all pull requests targeting the main branch, especially important for fork PRs.
+=== Integration / E2E tests — deferred
 
-=== Avoiding Duplicate Runs
-
-When you push to a feature branch that has an open PR, both triggers fire simultaneously:
-
-1. `push` trigger: "A push to `feature/*` occurred"
-2. `pull_request` trigger: "The PR was updated"
-
-The `if` condition on the job prevents duplicate runs by checking the event type and repository:
+The long-running `reusable-maven-integration-tests.yml` suites are deferred:
+callers trigger them only on the default branch (post-merge) and on pull
+requests — never on every feature-branch push. Because non-default branches are
+not in the push list, there is one run per PR update and no push/PR duplicate,
+so no caller `if:` is needed:
 
 [source,yaml]
 ----
-if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 ----
 
-This means:
+=== Other build types — fork-only `if:` pattern (legacy)
 
-* **Push events**: Always run (handles internal branch pushes)
-* **Pull request events**: Only run if from a **fork** (external contributors)
+The npm and pyprojectx build callers still use the legacy fork-only `if:` guard:
+the push event verifies internal branches and the `pull_request` event runs only
+for forks.
 
-For internal branches, the push event already verifies the code, so we skip the redundant PR event.
-For fork PRs, the push event cannot trigger (forks can't trigger push events on the base repo), so we run the PR event.
+[source,yaml]
+----
+jobs:
+  build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+----
+
+This avoids duplicate runs but produces only a *branch* analysis for internal
+PRs (no pull-request analysis); migrating npm/pyprojectx to the gate-based
+pattern is a planned follow-up.
 
 === Path Filtering for Documentation-Only Changes
 
@@ -162,10 +188,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -391,9 +417,12 @@ Both propagation jobs use `continue-on-error: true`, so propagation failures nev
 ----
 name: Integration Tests
 
+# Deferred: long-running suites build only on main (post-merge) and on PRs —
+# never on every feature-branch push. No caller `if:` is needed (non-main
+# branches are not in the push list, so there is no push/PR duplicate).
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -403,7 +432,6 @@ permissions:
 
 jobs:
   integration-tests:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       report-name: my-it-report
@@ -423,9 +451,12 @@ jobs:
 ----
 name: E2E Tests
 
+# Deferred: long-running suites build only on main (post-merge) and on PRs —
+# never on every feature-branch push. No caller `if:` is needed (non-main
+# branches are not in the push list, so there is no push/PR duplicate).
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -435,7 +466,6 @@ permissions:
 
 jobs:
   e2e-tests:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       report-name: e2e-playwright-report

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -45,10 +45,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -10,12 +10,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # the reusable workflow's gate reads open PRs to skip redundant push builds
 
 jobs:
   build:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       # Override project.yml settings with explicit inputs

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -3,6 +3,10 @@
 # Path filtering is handled inside the reusable workflow via project.yml settings.
 name: Maven Build
 
+# Every push builds (quality + Sonar branch analysis); every PR builds (Sonar
+# pull-request analysis). The reusable workflow's gate skips a push build when an
+# open PR already covers that commit, so there is no push/PR duplicate — no caller
+# `if:` is needed. The gate reads open PRs, hence `pull-requests: read` below.
 on:
   push:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
@@ -12,12 +16,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/workflow-examples/maven-integration-tests-caller.yml
+++ b/docs/workflow-examples/maven-integration-tests-caller.yml
@@ -2,9 +2,14 @@
 # Runs integration/E2E tests via Maven with optional report deployment to cuioss.github.io.
 name: Integration Tests
 
+# Integration/E2E are the long-running suites, so they are deferred: they build
+# only on the default branch (post-merge) and on pull requests — never on every
+# feature-branch push. Because non-default branches are not in the push list,
+# there is one run per PR update and no push/PR duplicate, so no caller `if:` is
+# needed (a fresh feature push to a PR'd branch runs via the pull_request event).
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -14,9 +19,6 @@ permissions:
 
 jobs:
   integration-tests:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       report-name: my-it-report


### PR DESCRIPTION
## Problem

The caller workflows used a fork-only `if:` guard that ran the build on **push** for internal branches and **skipped** the `pull_request` event for same-repo PRs (to avoid duplicate runs). Consequence: internal branches only ever got a Sonar **branch** analysis, never a **pull-request** analysis.

- `api/components/show?component=<key>` → 200 (project + main analysis exist)
- `api/measures/component?...&pullRequest=<n>` → **404** (no PR analysis)

So SonarCloud PR decoration and plan-marshall's `sonar-roundtrip` got nothing for internal PRs, and the documented "stuck PR" (GitHub drops the push event) could never build.

## Fix — gate inside `reusable-maven-build.yml`

A `gate` job decides whether to run:
- **push to a non-default branch with an open PR** → skip (the PR's own run builds the commit, with PR-scoped Sonar)
- **push to a branch with no open PR** → build (branch analysis + quality)
- **default branch** → always build (baseline + snapshot deploy)
- **pull_request / workflow_dispatch** → always build

The always-green `conclusion` job stays the branch-protection required check, so a gated skip still reports success. This makes the caller's fork-only `if:` unnecessary.

## Caller structure changes (templates + docs)

- **Maven build callers:** drop the `if:`, add `pull-requests: read` (the gate reads open PRs). Quality + Sonar now run on **every** push, with PR analysis whenever a PR exists, and no push/PR duplicate.
- **Integration/E2E callers:** deferred — `push: [main] + pull_request` only (no `if:`). Long suites no longer run on every feature push; one run per PR update, no duplicate.
- **npm / pyprojectx callers:** retain the legacy fork-only `if:` (gate-migration is a planned follow-up).

## Scope / rollout

Scoped to the Maven build (which already has the robust always-green `conclusion` job) per decision. Consumers pick up the new SHA automatically on release; the structural caller change is rolled out per consumer separately.

Local `./pw verify` could not run (broken local Homebrew Python 3.14 framework, unrelated to these YAML/AsciiDoc-only changes); CI runs the real verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized gate to intelligently skip redundant Maven push builds when an open pull request already covers the same commit.

* **Documentation**
  * Updated workflow docs and Maven caller/integration examples to reflect the gate-based deduplication approach, adjusted `pull-requests: read` permissions, and narrowed long-running suites to `main` push/PR triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->