### PR TITLE
feat(ci): extend skip-push-if-PR gate to npm and pyprojectx builds

### DIFF
--- a/.github/workflows/python-verify.yml
+++ b/.github/workflows/python-verify.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # the reusable workflow's gate reads open PRs to skip redundant push runs
 
 jobs:
   verify:

--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -182,3 +182,34 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONARCLOUD_URL: https://sonarcloud.io
+
+  # Gate job for branch protection — always runs, reports the aggregate result.
+  # Require `build / conclusion` in branch protection (uniform with the Maven build).
+  conclusion:
+    if: always()
+    needs: [gate, config, build, sonar-build]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Evaluate workflow result
+        run: |
+          # Gate skipped this run (a push whose commit is covered by an open PR) —
+          # the downstream jobs are skipped on purpose, so report success.
+          if [[ "${{ needs.gate.outputs.run }}" != "true" ]]; then
+            echo "Gate skipped this run (open PR covers the commit)"
+            exit 0
+          fi
+          if [[ "${{ needs.config.result }}" == "failure" ]]; then
+            echo "::error::config job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.build.result }}" == "cancelled" ]]; then
+            echo "::error::build job failed or was cancelled"
+            exit 1
+          fi
+          # Sonar: failure is an error; skipped is OK (disabled, dependabot, etc.)
+          if [[ "${{ needs.sonar-build.result }}" == "failure" || "${{ needs.sonar-build.result }}" == "cancelled" ]]; then
+            echo "::error::sonar-build job failed"
+            exit 1
+          fi
+          echo "All jobs passed or were correctly skipped"

--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -193,14 +193,19 @@ jobs:
     steps:
       - name: Evaluate workflow result
         run: |
-          # Gate skipped this run (a push whose commit is covered by an open PR) —
-          # the downstream jobs are skipped on purpose, so report success.
+          # A gate-job failure/cancellation must fail — never mask it as a skip.
+          if [[ "${{ needs.gate.result }}" != "success" ]]; then
+            echo "::error::gate job did not succeed (${{ needs.gate.result }})"
+            exit 1
+          fi
+          # Gate deliberately skipped this run (a push whose commit is covered by an
+          # open PR) — the downstream jobs are skipped on purpose, so report success.
           if [[ "${{ needs.gate.outputs.run }}" != "true" ]]; then
             echo "Gate skipped this run (open PR covers the commit)"
             exit 0
           fi
-          if [[ "${{ needs.config.result }}" == "failure" ]]; then
-            echo "::error::config job failed"
+          if [[ "${{ needs.config.result }}" == "failure" || "${{ needs.config.result }}" == "cancelled" ]]; then
+            echo "::error::config job failed or was cancelled"
             exit 1
           fi
           if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.build.result }}" == "cancelled" ]]; then

--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -27,8 +27,58 @@ permissions:
   contents: read
 
 jobs:
+  # Decide whether this run should proceed. Skips a push-triggered build when an
+  # open PR already covers the same branch — the PR's own run builds that commit
+  # (and produces a Sonar pull-request analysis), so the push build is redundant.
+  # A push to a branch with no open PR still builds (branch analysis + quality),
+  # and the default branch always builds.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether to run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # Non-push events (pull_request, workflow_dispatch, …) always run.
+          if [[ "$EVENT_NAME" != "push" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # The default branch always runs (post-merge baseline).
+          if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Push to a non-default branch: skip if an open SAME-REPO PR already
+          # covers it — the pull_request run builds the same commit (with PR-scoped
+          # Sonar). Only internal PRs count: a fork PR that happens to reuse this
+          # branch name builds a different repo's commit, so cross-repository PRs
+          # are excluded (gh's --head matches a bare branch name across forks).
+          # Fail open — a transient lookup error runs the build rather than skipping it.
+          if ! count="$(gh pr list --repo "$GH_REPO" --head "$REF_NAME" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)] | length')"; then
+            echo "PR lookup failed for '$REF_NAME' — defaulting to run push build"
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "${count:-0}" -gt 0 ]]; then
+            echo "Open same-repo PR exists for '$REF_NAME' — skipping push build (the PR run builds this commit)"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open same-repo PR for '$REF_NAME' — running push build"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Read project.yml configuration to use as defaults
   config:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -29,7 +29,56 @@ permissions:
   contents: read
 
 jobs:
+  # Decide whether this run should proceed. Skips a push-triggered run when an
+  # open PR already covers the same branch — the PR's own run verifies that commit,
+  # so the push run is redundant. A push to a branch with no open PR still runs,
+  # and the default branch always runs.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether to run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # Non-push events (pull_request, workflow_dispatch, …) always run.
+          if [[ "$EVENT_NAME" != "push" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # The default branch always runs.
+          if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Push to a non-default branch: skip if an open SAME-REPO PR already
+          # covers it — the pull_request run verifies the same commit. Only internal
+          # PRs count: a fork PR that happens to reuse this branch name verifies a
+          # different repo's commit, so cross-repository PRs are excluded (gh's
+          # --head matches a bare branch name across forks). Fail open — a transient
+          # lookup error runs the verification rather than skipping it.
+          if ! count="$(gh pr list --repo "$GH_REPO" --head "$REF_NAME" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)] | length')"; then
+            echo "PR lookup failed for '$REF_NAME' — defaulting to run push verification"
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "${count:-0}" -gt 0 ]]; then
+            echo "Open same-repo PR exists for '$REF_NAME' — skipping push run (the PR run verifies this commit)"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open same-repo PR for '$REF_NAME' — running push verification"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   verify:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -118,3 +118,25 @@ jobs:
             .pytest_cache/
             .mypy_cache/
           retention-days: 5
+
+  # Gate job for branch protection — always runs, reports the aggregate result.
+  # Require `verify / conclusion` in branch protection (uniform with the Maven build).
+  conclusion:
+    if: always()
+    needs: [gate, verify]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Evaluate workflow result
+        run: |
+          # Gate skipped this run (a push whose commit is covered by an open PR) —
+          # the verify job is skipped on purpose, so report success.
+          if [[ "${{ needs.gate.outputs.run }}" != "true" ]]; then
+            echo "Gate skipped this run (open PR covers the commit)"
+            exit 0
+          fi
+          if [[ "${{ needs.verify.result }}" == "failure" || "${{ needs.verify.result }}" == "cancelled" ]]; then
+            echo "::error::verify job failed or was cancelled"
+            exit 1
+          fi
+          echo "verify passed or was correctly skipped"

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -129,8 +129,13 @@ jobs:
     steps:
       - name: Evaluate workflow result
         run: |
-          # Gate skipped this run (a push whose commit is covered by an open PR) —
-          # the verify job is skipped on purpose, so report success.
+          # A gate-job failure/cancellation must fail — never mask it as a skip.
+          if [[ "${{ needs.gate.result }}" != "success" ]]; then
+            echo "::error::gate job did not succeed (${{ needs.gate.result }})"
+            exit 1
+          fi
+          # Gate deliberately skipped this run (a push whose commit is covered by an
+          # open PR) — the verify job is skipped on purpose, so report success.
           if [[ "${{ needs.gate.outputs.run }}" != "true" ]]; then
             echo "Gate skipped this run (open PR covers the commit)"
             exit 0

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -60,23 +60,27 @@ on:
   workflow_dispatch:
 ----
 
-=== Other build types — fork-only `if:` pattern (legacy)
+=== npm and pyprojectx builds — same gate
 
-The npm and pyprojectx build callers still use the legacy fork-only `if:` guard:
-the push event verifies internal branches and the `pull_request` event runs only
-for forks.
+`reusable-npm-build.yml` and `reusable-pyprojectx-verify.yml` carry the **same
+`gate` job** as the Maven build: a push to a non-default branch is skipped when an
+open same-repo PR already covers the commit, so the caller needs no `if:` and only
+adds `pull-requests: read`.
 
 [source,yaml]
 ----
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
 ----
 
-This avoids duplicate runs but produces only a *branch* analysis for internal
-PRs (no pull-request analysis); migrating npm/pyprojectx to the gate-based
-pattern is a planned follow-up.
+These workflows have no aggregate `conclusion` job; the gate-skipped push run
+simply reports its build/verify jobs as *skipped* (non-blocking), and the
+pull_request run provides the green build that the PR merges on.
 
 === Path Filtering for Documentation-Only Changes
 
@@ -662,11 +666,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   verify:
-    # Run on push, OR on pull_request only if from a fork
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
 ----
 
@@ -718,11 +721,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
-    # Run on push, OR on pull_request only if from a fork
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -78,9 +78,10 @@ jobs:
     uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
 ----
 
-These workflows have no aggregate `conclusion` job; the gate-skipped push run
-simply reports its build/verify jobs as *skipped* (non-blocking), and the
-pull_request run provides the green build that the PR merges on.
+Like the Maven build, both workflows carry an always-green `conclusion` job that
+is the branch-protection required check (`build / conclusion` for npm,
+`verify / conclusion` for pyprojectx), so a gate-skipped push run still reports a
+green `conclusion` rather than a skipped job.
 
 === Path Filtering for Documentation-Only Changes
 

--- a/docs/workflow-examples/npm-build-caller.yml
+++ b/docs/workflow-examples/npm-build-caller.yml
@@ -11,12 +11,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # the reusable workflow's gate reads open PRs to skip redundant push builds
 
 jobs:
   build:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-npm-build.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -11,12 +11,10 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # the reusable workflow's gate reads open PRs to skip redundant push runs
 
 jobs:
   verify:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-pyprojectx-verify.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     # Optional inputs (all have sensible defaults):
     # with:


### PR DESCRIPTION
Extends the gate-based push/PR dedup (shipped for Maven in v0.6.7) to the npm and pyprojectx build workflows.

- `reusable-npm-build.yml` + `reusable-pyprojectx-verify.yml`: add the same `gate` job — a push to a non-default branch is skipped when an open same-repo PR already covers the commit (the PR run builds it). Default branch + PR + dispatch always run; fork PRs excluded via `isCrossRepository`; fail-open on lookup error.
- Each also gets an always-green `conclusion` aggregate job (mirroring Maven), so a gate-skipped push run reports a green `conclusion` and branch protection can uniformly require `build / conclusion` (npm) / `verify / conclusion` (pyprojectx).
- Caller templates (`npm-build-caller.yml`, `pyprojectx-verify-caller.yml`): drop the fork-only `if:`, add `pull-requests: read`.
- Docs updated; the legacy-`if:` section is gone.

Enables adapting playwright-test-artifacts (npm) and plan-marshall (pyprojectx).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD efficiency by adding gate-based deduplication that can skip redundant push runs on non-default branches when an open same-repository pull request already covers the commit.
  * Updated reusable build/verification workflows to produce consistent, branch-protection-friendly overall pass/fail results.
* **Documentation**
  * Revised workflow documentation and examples to remove caller-side conditional guards and to add `pull-requests: read` permissions where needed for pull-request visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->