### PR TITLE
release: prepare 0.6.8

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.6.7
+  current-version: 0.6.8
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.6.8 for release (skip-push-if-PR gate extended to npm + pyprojectx builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->