### PR TITLE
docs(ci): branch-protection conclusion checks for all build types + cuioss-org self-consumer note

### DIFF
--- a/.claude/commands/apply-branch-protection.md
+++ b/.claude/commands/apply-branch-protection.md
@@ -29,7 +29,7 @@ Apply cuioss organization branch protection rulesets to a single repository with
      - Reusable **npm build** → `build / conclusion`
      - Reusable **pyprojectx verify** → `verify / conclusion`
    - The `conclusion` job always runs and reports the aggregate result, so it stays green when the gate skips a redundant push build and when only docs/config changed — whereas requiring individual job names blocks those PRs because skipped jobs never report status.
-   - Legacy (pre-conclusion): Individual checks like `build / build (21)`, `build / build (25)`, `build / sonar-build`, or `verify / verify` block docs-only and gate-skipped PRs — migrate them to the matching `… / conclusion` check above.
+   - Legacy (pre-conclusion): Individual checks like `build / build (21)`, `build / build (25)`, `build / sonar-build`, or `verify / verify` block docs-only and gate-skipped PRs — migrate them to the matching `<job> / conclusion` check above.
 
 4. **Ask User for Required Reviews**
    - Use AskUserQuestion

--- a/.claude/commands/apply-branch-protection.md
+++ b/.claude/commands/apply-branch-protection.md
@@ -23,9 +23,13 @@ Apply cuioss organization branch protection rulesets to a single repository with
      - **Reusable workflow callers** (target state): Check names are prefixed with the calling job name, e.g. `build / build (21)`, `build / build (25)`, `build / sonar-build`
      - **Inline workflows** (legacy): Check names are unprefixed, e.g. `build (21)`, `build (25)`, `sonar-build`
    - When migrating from inline to reusable workflows, the check names CHANGE. Use the prefixed names that the reusable workflow will produce, not the legacy names from `--list-checks`
-   - The standard required check for repos using the reusable Maven build workflow is: `build / conclusion`
-   - For repos also using integration tests, add: `integration-tests / conclusion`
-   - Legacy (pre-conclusion): Individual checks like `build / build (21)`, `build / build (25)`, `build / sonar-build` block docs-only PRs because skipped jobs never report status
+   - The standard required check, per build workflow, is its always-green `conclusion` gate job (uniform across all build types):
+     - Reusable **Maven build** → `build / conclusion`
+     - Reusable **integration/E2E tests** → `integration-tests / conclusion` (and `e2e-tests / conclusion` if used)
+     - Reusable **npm build** → `build / conclusion`
+     - Reusable **pyprojectx verify** → `verify / conclusion`
+   - The `conclusion` job always runs and reports the aggregate result, so it stays green when the gate skips a redundant push build and when only docs/config changed — whereas requiring individual job names blocks those PRs because skipped jobs never report status.
+   - Legacy (pre-conclusion): Individual checks like `build / build (21)`, `build / build (25)`, `build / sonar-build`, or `verify / verify` block docs-only and gate-skipped PRs — migrate them to the matching `… / conclusion` check above.
 
 4. **Ask User for Required Reviews**
    - Use AskUserQuestion

--- a/.claude/commands/setup-consumer-repo.md
+++ b/.claude/commands/setup-consumer-repo.md
@@ -40,7 +40,7 @@ Orchestrate the full setup of a cuioss consumer repository by running all four s
    - Run `/apply-branch-protection {repo-name}`
    - This configures: branch protection ruleset with status checks and review requirements
    - Follow the interactive prompts to select checks and review count
-   - **IMPORTANT**: Use `build / conclusion` as the single required check for the Maven build workflow (and `integration-tests / conclusion` for integration tests). This gate job handles both code and docs-only PRs correctly. Do NOT require individual job names like `build / build (21)` — they block docs-only PRs because skipped jobs never report status.
+   - **IMPORTANT**: Use the always-green `conclusion` gate job as the single required check per build workflow — `build / conclusion` (Maven build **and** npm build), `verify / conclusion` (pyprojectx verify), `integration-tests / conclusion` (and `e2e-tests / conclusion`) for integration/E2E. This gate job handles code, docs-only, and gate-skipped push PRs correctly. Do NOT require individual job names like `build / build (21)` or `verify / verify` — they block docs-only and gate-skipped PRs because skipped jobs never report status.
 
 8. **Update CLAUDE.md Sections**
    - Check if `{local-path}/CLAUDE.md` exists

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -83,6 +83,17 @@ is the branch-protection required check (`build / conclusion` for npm,
 `verify / conclusion` for pyprojectx), so a gate-skipped push run still reports a
 green `conclusion` rather than a skipped job.
 
+=== cuioss-organization itself
+
+cuioss-organization is its own consumer: its `python-verify.yml` calls the
+reusable pyprojectx verify workflow by **local `./` path** (not a SHA), so it is
+intentionally NOT in the `consumers` list and the release bot never opens
+SHA-bump PRs for it. It still follows the gate pattern like every other repo —
+the caller drops the fork-only `if:`, grants `pull-requests: read`, and requires
+`verify / conclusion`. When the gate or `conclusion` contract changes, update
+`python-verify.yml` in the same PR as the reusable-workflow change (it picks the
+new version up immediately via the local path).
+
 === Path Filtering for Documentation-Only Changes
 
 The reusable Maven build workflow includes a built-in `check-changes` job using https://github.com/dorny/paths-filter[dorny/paths-filter] that skips build/sonar/deploy jobs when only documentation or config files changed. This is handled entirely inside `reusable-maven-build.yml` — callers do not need any path filtering logic.


### PR DESCRIPTION
Closes the setup-skill/documentation gaps after extending the gate to npm + pyprojectx:

- **apply-branch-protection.md** + **setup-consumer-repo.md**: the required check is the always-green `conclusion` job per build type — `build / conclusion` (Maven **and** npm), `verify / conclusion` (pyprojectx), `integration-tests / conclusion` / `e2e-tests / conclusion`. Migrate legacy `verify / verify` / individual-job requirements.
- **Workflows.adoc**: document cuioss-organization as its own gate-following consumer (local `./` ref, intentionally not in the consumers list).

Live rulesets for cuioss-organization and plan-marshall were also switched from `verify / verify` to `verify / conclusion` (playwright had no pinned check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated branch protection status check guidance to require each build workflow’s always-green `… / conclusion` gate job, including explicit mappings for Maven, npm, verify, integration, and E2E.
  * Clarified why `conclusion` remains green for skipped/redundant builds (e.g., docs-only changes) and warned against requiring job-specific legacy statuses.
  * Expanded instructions for consumer repository setup, including how the organization repository’s reusable-workflow usage is handled for release automation and SHA bump PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->