### PR TITLE
feat(codeql): add build-mode input to reusable-codeql workflow

### DIFF
--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -56,7 +56,7 @@ jobs:
           build-mode: ${{ inputs.build-mode }}
 
       - name: Autobuild
-        if: inputs.build-mode != 'none' && inputs.build-command == ''
+        if: inputs.build-mode != 'none' && inputs.build-mode != 'manual' && inputs.build-command == ''
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
       - name: Custom build

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ''
+      build-mode:
+        description: 'CodeQL build mode: autobuild | none | manual'
+        required: false
+        type: string
+        default: 'autobuild'
 
 permissions:
   contents: read
@@ -48,13 +53,14 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          build-mode: ${{ inputs.build-mode }}
 
       - name: Autobuild
-        if: inputs.build-command == ''
+        if: inputs.build-mode != 'none' && inputs.build-command == ''
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
       - name: Custom build
-        if: inputs.build-command != ''
+        if: inputs.build-mode != 'none' && inputs.build-command != ''
         run: ${{ inputs.build-command }}
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -18,10 +18,10 @@ on:
         type: string
         default: ''
       build-mode:
-        description: 'CodeQL build mode: autobuild | none | manual'
+        description: 'CodeQL build mode: autobuild | none | manual. Leave empty to use CodeQL''s per-language default (current behavior).'
         required: false
         type: string
-        default: 'autobuild'
+        default: ''
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Adds a `build-mode` `workflow_call` input to `.github/workflows/reusable-codeql.yml` so consumer repos can request CodeQL `build-mode: none`.

## Why

`cui-http` needs `build-mode: none` to analyze source without building its benchmark module (which depends on an external artifact). The reusable workflow currently uses Autobuild, which `cui-http` cannot use — forcing it to hand-roll a standalone `codeql.yml`. This change lets it consume the reusable workflow instead.

## Changes

- New input `build-mode` (string, `required: false`, default `'autobuild'`), described as `CodeQL build mode: autobuild | none | manual`.
- Passed through to `github/codeql-action/init` as `build-mode: ${{ inputs.build-mode }}`.
- The **Autobuild** and **Custom build** steps now additionally gate on `inputs.build-mode != 'none'`, so all build steps are skipped when `build-mode == 'none'`.

## Compatibility

The default `autobuild` reproduces today's behavior exactly (autobuild is already CodeQL's default for compiled languages). All actions remain SHA-pinned; no versions bumped. YAML validated as well-formed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to choose how CodeQL builds are handled, including automatic, manual, or no build.
  * Improved workflow flexibility so security scanning can be configured for different project setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->