### PR TITLE
chore: rename consumer OAuthSheriff -> TokenSheriff

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -26,6 +26,6 @@ consumers:
   - cui-test-value-objects
   - cuioss-parent-pom
   - nifi-extensions
-  - OAuthSheriff
   - plan-marshall
   - playwright-test-artifacts
+  - TokenSheriff


### PR DESCRIPTION
Rename the stale consumer `OAuthSheriff` -> `TokenSheriff` (the repo was renamed). Moved to its alphabetical position so the `consumers` list stays sorted.

Editing this repo's `project.yml` does not trigger a release (org `release.yml` is `workflow_dispatch` only).

Labeled `skip-coderabbit` (central CodeRabbit config exclusion) — verifying the skip again.