### PR TITLE
docs: unify bot-skip label as skip-bot-review

### DIFF
--- a/docs/automatic-review/README.md
+++ b/docs/automatic-review/README.md
@@ -12,6 +12,21 @@ Each doc covers the review anatomy, a signal/noise table, the config levers (and
 suppressed), and the automation nuances (dedup across reviewers, the "Prompt for AI Agents"
 prompt-injection caveat, correct-≠-in-scope).
 
+## Shared skip label
+
+`skip-bot-review` is the org-wide "don't auto-review this PR" label. Support is uneven — only
+CodeRabbit honors it from central config today:
+
+| Reviewer | Honors `skip-bot-review`? | How |
+|---|---|---|
+| CodeRabbit | ✅ centrally | `labels: ["!skip-bot-review"]` in `cuioss/coderabbit/.coderabbit.yaml` |
+| Sourcery | ⚠️ only if wired per-repo | add `github.ignore_labels: [skip-bot-review]` to each repo's `.sourcery.yaml` (not yet done) |
+| Gemini | ❌ no label skip exists | `.gemini/config.yaml` only supports global `code_review: disable`, file `ignore_patterns`, and a severity threshold — no per-PR label opt-out |
+
+So today, applying `skip-bot-review` reliably silences **CodeRabbit**; Sourcery keeps reviewing
+unless its per-repo config is added, and Gemini cannot be skipped by label at all. Create the
+label per repo where you want to use it (`gh label create skip-bot-review`).
+
 **Downstream:** plan-marshall consumes these reviewers through its `pr-comment` findings pipeline.
 The per-reviewer triage rules live in plan-marshall at `.plan/auto-review/{code-rabbit,sourcery}.md`
 and link back here as the source of truth for signal/noise and configuration.

--- a/docs/automatic-review/coderabbit.md
+++ b/docs/automatic-review/coderabbit.md
@@ -86,7 +86,7 @@ The config lives in [`cuioss/coderabbit/.coderabbit.yaml`](https://github.com/cu
 | `enable_prompt_for_ai_agents: true` | **Keep** the machine-readable payload (signal) |
 
 Skip surface: `auto_review.ignore_usernames` (`dependabot[bot]`, `cuioss-release-bot[bot]`) and
-the `!skip-coderabbit` label opt-out.
+the shared **`!skip-bot-review`** label opt-out (see [README](README.md#shared-skip-label)).
 
 Further optional levers if more trimming is wanted: `changed_files_summary: false`,
 `estimate_code_review_effort: false`, `related_issues`/`related_prs: false`,

--- a/docs/automatic-review/sourcery.md
+++ b/docs/automatic-review/sourcery.md
@@ -24,7 +24,9 @@ unlike CodeRabbit it is not managed in a repo). The only file-based lever is per
 
 Parity gaps vs. the central CodeRabbit config:
 
-- **Skip-by-label** is per-repo (`.sourcery.yaml github.ignore_labels`), not central like `!skip-coderabbit`.
+- **Skip-by-label** is per-repo, not central like CodeRabbit's `!skip-bot-review`. To make
+  Sourcery honor the shared `skip-bot-review` label, add `github.ignore_labels: [skip-bot-review]`
+  to each repo's `.sourcery.yaml` (**not yet wired** — see [README](README.md#shared-skip-label)).
 - **Skip bot PRs by author** has no documented Sourcery equivalent — it may review `dependabot[bot]` / `cuioss-release-bot[bot]` PRs unless gated by a label. Confirm in the dashboard.
 
 Docs: [Code-Review Configuration](https://docs.sourcery.ai/Code-Review/Configuration/) ·


### PR DESCRIPTION
Rename the CodeRabbit-specific `skip-coderabbit` to the shared **`skip-bot-review`** and document the honoring reality (added a *Shared skip label* section with a matrix):

- **CodeRabbit** — honors `!skip-bot-review` centrally (config already updated in `cuioss/coderabbit`).
- **Sourcery** — only if `github.ignore_labels: [skip-bot-review]` is added per-repo (not yet wired).
- **Gemini** — no per-PR label skip exists (only global disable / file ignore_patterns).

This PR is itself labeled `skip-bot-review` — a live check that CodeRabbit skips it.

## Summary by Sourcery

Document the shared `skip-bot-review` label as the org-wide mechanism for skipping automatic bot reviews and align CodeRabbit and Sourcery docs to reference it consistently.

Documentation:
- Add a shared skip label section describing `skip-bot-review` support across CodeRabbit, Sourcery, and Gemini.
- Clarify Sourcery configuration for honoring the `skip-bot-review` label via `github.ignore_labels` in per-repo `.sourcery.yaml` files.
- Update CodeRabbit documentation to reference the shared `!skip-bot-review` label as the standard opt-out.