### PR TITLE
feat(workflow): support GitHub merge queue (merge_group) in maven workflows

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -146,10 +146,12 @@ jobs:
         id: config
         uses: cuioss/cuioss-organization/.github/actions/read-project-config@181cc6a24d4c2b6fe7378b9ac94ac3df4665de7b # v0.7.0
 
-  # Check if only documentation/config files changed (skip build if so)
+  # Check if only documentation/config files changed (skip build if so).
+  # Skipped on merge_group: paths-filter cannot auto-detect a diff base there,
+  # and a merge-queue run must always build the full merge result anyway.
   check-changes:
     needs: config
-    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only
+    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -228,9 +230,12 @@ jobs:
       - name: Build with Maven, Java ${{ matrix.version }}
         run: ./mvnw --no-transfer-progress verify -Dmaven.compiler.release=${{ matrix.version }}
 
+  # Skipped on merge_group: there is no PR context, and analyzing the throwaway
+  # gh-readonly-queue/* branch would pollute Sonar and slow the queue — the PR
+  # run has already passed the Sonar gate before entering the queue.
   sonar-build:
     needs: [config, check-changes, build]
-    if: ${{ always() && needs.check-changes.outputs.should-build != 'false' && needs.build.result == 'success' && (needs.config.outputs.sonar-enabled != 'false' && inputs.enable-sonar) && !((needs.config.outputs.sonar-skip-on-dependabot == 'true' || inputs.skip-sonar-on-dependabot) && github.actor == 'dependabot[bot]') }}
+    if: ${{ always() && needs.check-changes.outputs.should-build != 'false' && needs.build.result == 'success' && github.event_name != 'merge_group' && (needs.config.outputs.sonar-enabled != 'false' && inputs.enable-sonar) && !((needs.config.outputs.sonar-skip-on-dependabot == 'true' || inputs.skip-sonar-on-dependabot) && github.actor == 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -101,10 +101,12 @@ jobs:
         id: config
         uses: cuioss/cuioss-organization/.github/actions/read-project-config@181cc6a24d4c2b6fe7378b9ac94ac3df4665de7b # v0.7.0
 
-  # Check if only documentation/config files changed (skip tests if so)
+  # Check if only documentation/config files changed (skip tests if so).
+  # Skipped on merge_group: paths-filter cannot auto-detect a diff base there,
+  # and a merge-queue run must always test the full merge result anyway.
   check-changes:
     needs: config
-    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only
+    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/workflow-examples/maven-build-caller-custom.yml
+++ b/docs/workflow-examples/maven-build-caller-custom.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required when the repo uses a GitHub merge queue: without it the queued
+  # checks never report and the queue times out. Inert for repos without one.
+  merge_group:
 
 permissions:
   contents: read

--- a/docs/workflow-examples/maven-build-caller.yml
+++ b/docs/workflow-examples/maven-build-caller.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required when the repo uses a GitHub merge queue: without it the queued
+  # checks never report and the queue times out. Inert for repos without one.
+  merge_group:
 
 permissions:
   contents: read

--- a/docs/workflow-examples/maven-integration-tests-caller.yml
+++ b/docs/workflow-examples/maven-integration-tests-caller.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required when the repo uses a GitHub merge queue: without it the queued
+  # checks never report and the queue times out. Inert for repos without one.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Repos that enable a GitHub merge queue hang today: none of the reusable maven workflows run on `merge_group` events, so the merge group's required checks (`build / conclusion`, `integration-tests / conclusion`, `e2e-tests / conclusion`) never report and the queue silently dequeues the PR after ~1h. Observed live on cuioss/TokenSheriff#554 (added to queue 17:03, removed 18:07, no merge-group CI runs).

## Changes

**`reusable-maven-build.yml`**
- `check-changes`: skip on `merge_group`. `dorny/paths-filter` auto-detects a diff base only for `push`/`pull_request` and errors on other events; a merge-queue run must build the full merge result anyway. Downstream `if` conditions and `conclusion` already tolerate the skipped job (same path as `skip-on-docs-only: false`).
- `sonar-build`: skip on `merge_group`. No PR context exists there; analyzing the throwaway `gh-readonly-queue/*` branch would pollute Sonar and add ~10 min of queue latency per PR, and the PR run has already passed the Sonar gate before entering the queue. `conclusion` treats skipped Sonar as success.

**`reusable-maven-integration-tests.yml`**
- `check-changes`: same skip, same reasoning.

**Caller examples** (`maven-build-caller.yml`, `maven-build-caller-custom.yml`, `maven-integration-tests-caller.yml`)
- Add the `merge_group:` trigger with a rationale comment. Consumer repos must carry this trigger for their required checks to report inside a queue; it is inert for repos without one.

## Compatibility

Behavior on `push`/`pull_request`/`workflow_dispatch` is unchanged — every new condition is a `github.event_name != 'merge_group'` guard that only fires inside a merge group. Jobs already safe on merge_group were left untouched: `gate` (non-push events always run), `deploy-snapshot` (gated on `refs/heads/main`; merge groups run on `refs/heads/gh-readonly-queue/*`), and the report-deploy steps (gated to `push`/`workflow_dispatch`).

## Rollout

After release, consumer repos bump the pinned SHA and add `merge_group:` to their caller workflows, then enable the merge queue ruleset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub merge queue support to Maven build and integration test workflows.
  * Enabled queued checks to report correctly and avoid timeouts.

* **Bug Fixes**
  * Prevented documentation-only optimizations from skipping required merge queue builds and tests.
  * Disabled Sonar analysis during merge queue events where it is not applicable.

* **Documentation**
  * Updated workflow examples with merge queue trigger configuration and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->