### PR TITLE
chore(ci): cancel superseded PR runs + cache node_modules

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -68,6 +68,16 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run only for pull requests: pushing a new commit
+# to a PR makes the older run's result irrelevant, so freeing that runner speeds up
+# feedback. Grouped by caller workflow + ref + event so a push, a PR, and a
+# merge_group run never share a group. cancel-in-progress is deliberately limited to
+# pull_request: push runs on the default branch (snapshot deploy) and merge_group runs
+# (the merge queue) must always run to completion and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Decide whether this run should proceed. Skips a push-triggered build when an
   # open PR already covers the same branch — the PR's own run builds that commit
@@ -222,7 +232,12 @@ jobs:
         if: ${{ needs.config.outputs.npm-cache == 'true' || inputs.npm-cache }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.npm
+          # Cache npm's download cache AND installed node_modules so frontend builds
+          # skip re-download and re-link on a cache hit. Keyed on the lock/manifest
+          # files, so a dependency change busts it; a stale hit is simply overwritten.
+          path: |
+            ~/.npm
+            **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json', '**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
@@ -275,7 +290,12 @@ jobs:
         if: ${{ needs.config.outputs.npm-cache == 'true' || inputs.npm-cache }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.npm
+          # Cache npm's download cache AND installed node_modules so frontend builds
+          # skip re-download and re-link on a cache hit. Keyed on the lock/manifest
+          # files, so a dependency change busts it; a stale hit is simply overwritten.
+          path: |
+            ~/.npm
+            **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json', '**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
@@ -318,7 +338,12 @@ jobs:
         if: ${{ needs.config.outputs.npm-cache == 'true' || inputs.npm-cache }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.npm
+          # Cache npm's download cache AND installed node_modules so frontend builds
+          # skip re-download and re-link on a cache hit. Keyed on the lock/manifest
+          # files, so a dependency change busts it; a stale hit is simply overwritten.
+          path: |
+            ~/.npm
+            **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json', '**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-


### PR DESCRIPTION
## Summary

Two **additive, low-risk** build-time cuts to `reusable-maven-build.yml`. No change to the job DAG, the JDK matrix, or Sonar/deploy behaviour — so no per-repo coverage or policy impact.

### 1. Cancel superseded PR runs (`concurrency`)
Pushing a new commit to a PR makes the older in-progress run irrelevant; cancelling it frees the runner and speeds feedback.
- Group: `${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}` (per-repo by GitHub default).
- `cancel-in-progress` is **limited to `pull_request`** — default-branch `push` runs (snapshot deploy) and `merge_group` runs (merge queue) always run to completion and are **never cancelled**.

### 2. Cache `node_modules` (extends existing opt-in npm cache)
The existing `npm-cache`-gated step cached only `~/.npm` (npm's download cache). Frontend builds still re-ran `npm install` (re-link/extract) every job. This adds `**/node_modules` to the cached paths so a cache hit skips that too.
- Keyed on `hashFiles('**/package-lock.json', '**/package.json')` — a dependency change busts it; a stale hit is simply overwritten.
- Still gated behind the `npm-cache` input, so only repos that opt in are affected. The consumer-specific frontend-maven-plugin Node binary path (`target/node`) is intentionally **not** cached (git-ignored, wiped by `clean`, path varies per repo).

## Deliberately out of scope
The higher-risk items flagged in planning are **not** included (they change coverage/policy and need per-item sign-off): cutting `sonar-build`'s full re-`verify`, and reducing the PR JDK matrix. This PR is strictly additive.

## Blast radius
Consumed by every org repo via the release-bot SHA bump. Both changes are safe defaults; the concurrency gating cannot cancel `main` or merge-queue runs.