### PR TITLE
release: prepare 0.9.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.8.0
+  current-version: 0.9.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.9.0 for release.

Includes the reusable-maven-build build-time cuts from #174 (cancel superseded PR runs + cache node_modules).