### PR TITLE
chore(ci): treat .plan/** and .claude/** as non-code in docs-only gate

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -181,6 +181,8 @@ jobs:
             echo "  - '!**/*.adoc'"
             echo "  - '!**/*.md'"
             echo "  - '!doc/**'"
+            echo "  - '!.plan/**'"
+            echo "  - '!.claude/**'"
             echo "  - '!.github/project.yml'"
             echo "  - '!.github/dependabot.yml'"
             echo "  - '!LICENSE'"

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -126,6 +126,8 @@ jobs:
             echo "  - '!**/*.adoc'"
             echo "  - '!**/*.md'"
             echo "  - '!doc/**'"
+            echo "  - '!.plan/**'"
+            echo "  - '!.claude/**'"
             echo "  - '!.github/project.yml'"
             echo "  - '!.github/dependabot.yml'"
             echo "  - '!LICENSE'"


### PR DESCRIPTION
## Summary

The `check-changes` docs-only gate in `reusable-maven-build.yml` and
`reusable-maven-integration-tests.yml` classifies any diff outside
`**/*.adoc`, `**/*.md`, `doc/**`, `.github/project.yml`,
`.github/dependabot.yml`, `LICENSE`, `NOTICE` (plus per-repo
`paths-ignore-extra`) as "code", triggering a full build/integration-test/
e2e run.

`.plan/**` (plan-marshall bookkeeping — `marshal.json`, the generated
executor, plan state) and `.claude/**` (Claude Code project config) are
config-only directories present in multiple cuioss consumer repos
(nifi-extensions, cui-http, cui-java-tools, cuioss-parent-pom, and
others). A config-only change to these dirs currently triggers the same
expensive CI as a source change, with no runtime surface to actually
verify.

## Changes

- Added `.plan/**` and `.claude/**` to the built-in ignore-glob list in
  both `reusable-maven-build.yml` and `reusable-maven-integration-tests.yml`
  (identical two-line addition in each, alongside the existing `doc/**`
  pattern).

## Notes

- `.github/workflows/**` was deliberately NOT added — workflow-file changes
  are exactly what CI needs to run to validate.
- This only affects the reusable-workflow source; consumer repos pick it up
  once they bump their pinned SHA to the release that includes this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and integration test workflows to skip runs when changes are limited to planning or assistant configuration files.
  * Reduced unnecessary automated build and integration test executions for non-code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->