### PR TITLE
fix(ci): make docs-only gate actually skip via predicate-quantifier: every

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -193,9 +193,14 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      # predicate-quantifier MUST be 'every': the spec above is all-negation, and
+      # dorny's default 'some' ORs the patterns, so any non-.adoc file matches
+      # '!**/*.adoc' and the gate never skips. 'every' ANDs them, so a file counts
+      # as code only when it matches none of the ignore globs.
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: ${{ steps.build-filter.outputs.spec }}
 
   build:

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -138,9 +138,14 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      # predicate-quantifier MUST be 'every': the spec above is all-negation, and
+      # dorny's default 'some' ORs the patterns, so any non-.adoc file matches
+      # '!**/*.adoc' and the gate never skips. 'every' ANDs them, so a file counts
+      # as code only when it matches none of the ignore globs.
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: ${{ steps.build-filter.outputs.spec }}
 
   test:


### PR DESCRIPTION
## Summary

The `check-changes` docs-only gate has **never skipped a run** — for any repo, any change, since it was introduced in #83. This fixes it with a one-line input on each of the two `dorny/paths-filter` call sites.

This is the missing half of #177, which added `.plan/**` and `.claude/**` to a list that was already non-functional.

## Root cause

`check-changes` builds an **all-negation** filter spec:

```yaml
code:
  - '!**/*.adoc'
  - '!**/*.md'
  - '!doc/**'
  - '!.plan/**'
  ...
```

But `dorny/paths-filter` combines patterns *within* a filter using `patterns.some(...)` — **OR** — because the `predicate-quantifier` input defaults to `'some'` (`PredicateQuantifier.SOME`). The spec is written as if the patterns AND together, the way `paths-ignore` behaves.

Under OR, any file that is not an `.adoc` matches `'!**/*.adoc'`, and the filter short-circuits to `true`. To be excluded, a file would have to match *every* negation simultaneously — be an `.adoc` **and** an `.md` **and** under `doc/` **and** under `.plan/` — which is impossible. So `code` is unconditionally `true` for every changed file.

Observed in the wild on a `.plan/marshal.json`-only PR ([API-Sheriff#62](https://github.com/cuioss/API-Sheriff/pull/62)), which ran the full Java 25+26 matrix, Sonar, and integration tests:

```
[modified] .plan/marshal.json
##[group]Filter code = true
Matching files:
.plan/marshal.json [modified]
```

It matched as *code* despite `'!.plan/**'` being present in the spec.

## Fix

Set `predicate-quantifier: 'every'` on both call sites, which ANDs the patterns and yields the intended semantics: a file counts as code only when it matches **none** of the ignore globs.

`PredicateQuantifier.EVERY = 'every'` is supported at the pinned action SHA (`7b450ff`, v4.0.2).

## Verification

Evaluated against `picomatch` (the matcher dorny uses) with the exact production spec:

| file | `some` (before) | `every` (after) |
|------|-----------------|-----------------|
| `.plan/marshal.json` | `true` | **`false`** |
| `README.md` | `true` | **`false`** |
| `doc/guide.adoc` | `true` | **`false`** |
| `.claude/settings.json` | `true` | **`false`** |
| `api-sheriff/src/main/java/Foo.java` | `true` | `true` |
| `.github/workflows/maven.yml` | `true` | `true` |
| `pom.xml` | `true` | `true` |

Note the `before` column is `true` for *every* row — including `doc/guide.adoc`, the exact case the gate exists to catch.

## Notes

- **Mixed code+docs PRs still build.** A filter matches when *any* changed file qualifies, so one `.java` file among docs is enough to trigger the build.
- **Workflow files still build**, preserving the deliberate carve-out from #177 (`.github/workflows/**` was never added to the ignore list).
- **Merge-queue runs are unaffected** — `check-changes` is already skipped on `merge_group`, and `should-build != 'false'` means a skipped gate still builds.
- Scope is limited to the two workflows with a `check-changes` job (`reusable-maven-build.yml`, `reusable-maven-integration-tests.yml`); these are the only two `dorny/paths-filter` call sites in the repo.
- Consumer repos pick this up once they bump their pinned SHA to a release containing it (needs a `v0.10.1`).
