### PR TITLE
feat(branch-protection): org-managed opt-in merge queue

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -309,7 +309,7 @@ jobs:
           if [ -n "$RESULTS_FILE" ] && [ -f "$RESULTS_FILE" ]; then
             python3 workflow-scripts/verify-consumer-prs.py \
               --results-file "$RESULTS_FILE" \
-              --timeout 300
+              --timeout 900
             rm -f "$RESULTS_FILE"
           else
             echo "No results file found, skipping verification"

--- a/branch-protection/README.adoc
+++ b/branch-protection/README.adoc
@@ -122,6 +122,54 @@ When applied, the ruleset enforces:
 
 NOTE: The "up-to-date branches" requirement improves OpenSSF Scorecard score by ensuring PRs are rebased before merge, preventing integration issues.
 
+== Merge Queue (opt-in, org-managed)
+
+A GitHub merge queue is available as an **opt-in** ruleset (`main-merge-queue`),
+managed here rather than per-developer. It is separate from
+`main-branch-protection` so non-queue repos are unaffected.
+
+Key properties:
+
+* **`merge_method` is `SQUASH`** — matches the org merge policy
+  (`repo-settings` `squash_merge_commit_title=PR_TITLE`). Do not change this
+  without updating the merge policy.
+* Carries the **same `cuioss-release-bot` bypass actor** as
+  `main-branch-protection`, so the release workflow's direct push of the release
+  commit and tag to `main` keeps working. Without this bypass a mandatory queue
+  breaks releases.
+* Applied only to the repos listed under `merge_queue.merge_queue_repos` in
+  `config.json`.
+* Enabling a repo also removes any legacy `plan-marshall-merge-queue` ruleset
+  (the per-developer, bypass-less queue that plan-marshall's steward created).
+
+=== Prerequisites for a queued repo
+
+* The repo's caller workflow (e.g. `.github/workflows/maven.yml`) MUST trigger on
+  `merge_group`, or queue entries never receive their required checks and stall.
+* `delete_branch_on_merge=true` (already set org-wide by `repo-settings`) — the
+  queue deletes the head branch; propagation auto-merge no longer passes
+  `--delete-branch`.
+
+=== Usage
+
+[source,bash]
+----
+# Preview the merge-queue ruleset for one repo
+./setup-branch-protection.py --repo cuioss-parent-pom --enable-merge-queue --diff
+
+# Enable on one repo
+./setup-branch-protection.py --repo cuioss-parent-pom --enable-merge-queue --apply
+
+# Enable on every repo in merge_queue_repos
+./setup-branch-protection.py --enable-merge-queue
+
+# Remove the merge queue from one repo (and any legacy plan-marshall-merge-queue)
+./setup-branch-protection.py --repo cuioss-parent-pom --disable-merge-queue
+
+# Remove from every repo in merge_queue_repos
+./setup-branch-protection.py --disable-merge-queue
+----
+
 == Dry Run
 
 To test without applying changes, use `--diff`:

--- a/branch-protection/config.json
+++ b/branch-protection/config.json
@@ -31,5 +31,24 @@
         "enabled": true
       }
     }
+  },
+  "merge_queue": {
+    "$comment": "Opt-in, org-managed merge queue. Applied only to repos listed in merge_queue_repos via --enable-merge-queue. Carries the same cuioss-release-bot bypass as main-branch-protection so the release workflow's direct push to main keeps working. merge_method MUST stay SQUASH to match the org merge policy (repo-settings squash_merge_commit_title=PR_TITLE).",
+    "ruleset_name": "main-merge-queue",
+    "merge_method": "SQUASH",
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 5,
+    "min_entries_to_merge": 1,
+    "max_entries_to_merge": 5,
+    "min_entries_to_merge_wait_minutes": 5,
+    "check_response_timeout_minutes": 60,
+    "merge_queue_repos": [
+      "plan-marshall",
+      "cuioss-parent-pom",
+      "API-Sheriff",
+      "TokenSheriff",
+      "nifi-extensions",
+      "cui-open-rewrite"
+    ]
   }
 }

--- a/branch-protection/setup-branch-protection.py
+++ b/branch-protection/setup-branch-protection.py
@@ -537,6 +537,12 @@ def apply_merge_queue_ruleset(org: str, repo: str, config: dict, bypass_actor_id
     name = config["merge_queue"]["ruleset_name"]
     log_info(f"Enabling merge queue on {org}/{repo}...")
 
+    # Migration: drop the legacy plan-marshall-branded queue FIRST. GitHub may
+    # reject a second active merge_queue rule on the same branch, so we never
+    # want both to exist at once; on failure the repo is left with no queue
+    # (still PR-protected) rather than the bypass-less legacy queue.
+    delete_ruleset_by_name(org, repo, LEGACY_MERGE_QUEUE_NAME)
+
     payload_json = json.dumps(build_merge_queue_payload(config, bypass_actor_id))
     existing_id = get_existing_ruleset_id(org, repo, name)
 
@@ -559,9 +565,6 @@ def apply_merge_queue_ruleset(org: str, repo: str, config: dict, bypass_actor_id
         log_info("  ✓ Done")
     else:
         log_warn(f"  ⚠ Failed: {result.stderr}")
-
-    # Migration: drop the legacy plan-marshall-branded queue if present.
-    delete_ruleset_by_name(org, repo, LEGACY_MERGE_QUEUE_NAME)
 
 
 def verify_merge_queue_ruleset(org: str, repo: str, config: dict, bypass_actor_id: str) -> bool:

--- a/branch-protection/setup-branch-protection.py
+++ b/branch-protection/setup-branch-protection.py
@@ -21,6 +21,12 @@ YELLOW = "\033[1;33m"
 RED = "\033[0;31m"
 NC = "\033[0m"
 
+# Legacy per-developer merge-queue ruleset created by plan-marshall's steward.
+# It carried no bypass actor, which broke the release workflow's direct push to
+# main. The org-managed queue (config["merge_queue"]["ruleset_name"]) replaces it;
+# --enable/--disable-merge-queue remove any leftover legacy ruleset.
+LEGACY_MERGE_QUEUE_NAME = "plan-marshall-merge-queue"
+
 
 def log_info(msg: str) -> None:
     print(f"{GREEN}[INFO]{NC} {msg}", file=sys.stderr)
@@ -399,6 +405,256 @@ def verify_ruleset(
     return all_passed
 
 
+def build_merge_queue_payload(config: dict, bypass_actor_id: str) -> dict:
+    """Build the org-managed merge-queue ruleset payload.
+
+    Carries the same cuioss-release-bot bypass actor as main-branch-protection
+    so the release workflow's direct push to main keeps working under the queue.
+    """
+    mq = config["merge_queue"]
+    branch = config["ruleset"]["branch_pattern"]
+    return {
+        "name": mq["ruleset_name"],
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": [f"refs/heads/{branch}"],
+                "exclude": [],
+            }
+        },
+        "bypass_actors": [
+            {
+                "actor_id": int(bypass_actor_id),
+                "actor_type": "Integration",
+                "bypass_mode": "always",
+            }
+        ],
+        "rules": [
+            {
+                "type": "merge_queue",
+                "parameters": {
+                    "merge_method": mq.get("merge_method", "SQUASH"),
+                    "grouping_strategy": mq.get("grouping_strategy", "ALLGREEN"),
+                    "max_entries_to_build": mq.get("max_entries_to_build", 5),
+                    "min_entries_to_merge": mq.get("min_entries_to_merge", 1),
+                    "max_entries_to_merge": mq.get("max_entries_to_merge", 5),
+                    "min_entries_to_merge_wait_minutes": mq.get("min_entries_to_merge_wait_minutes", 5),
+                    "check_response_timeout_minutes": mq.get("check_response_timeout_minutes", 60),
+                },
+            }
+        ],
+    }
+
+
+_MERGE_QUEUE_PARAM_KEYS = (
+    "merge_method",
+    "grouping_strategy",
+    "max_entries_to_build",
+    "min_entries_to_merge",
+    "max_entries_to_merge",
+    "min_entries_to_merge_wait_minutes",
+    "check_response_timeout_minutes",
+)
+
+
+def normalize_merge_queue_for_comparison(ruleset: dict) -> dict:
+    """Extract comparable fields from a merge-queue ruleset."""
+    mq_rule = None
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") == "merge_queue":
+            params = rule.get("parameters", {})
+            mq_rule = {
+                "type": "merge_queue",
+                "parameters": {k: params.get(k) for k in _MERGE_QUEUE_PARAM_KEYS},
+            }
+    return {
+        "name": ruleset.get("name"),
+        "enforcement": ruleset.get("enforcement"),
+        "conditions": ruleset.get("conditions"),
+        "bypass_actors": [
+            {
+                "actor_id": actor.get("actor_id"),
+                "actor_type": actor.get("actor_type"),
+                "bypass_mode": actor.get("bypass_mode"),
+            }
+            for actor in ruleset.get("bypass_actors", [])
+        ],
+        "rules": [mq_rule] if mq_rule else [],
+    }
+
+
+def compute_merge_queue_diff(org: str, repo: str, config: dict, bypass_actor_id: str) -> dict:
+    """Compute diff between current and desired merge-queue ruleset."""
+    name = config["merge_queue"]["ruleset_name"]
+    existing = get_existing_ruleset(org, repo, name)
+    desired = build_merge_queue_payload(config, bypass_actor_id)
+
+    diff = {
+        "repository": f"{org}/{repo}",
+        "ruleset_name": name,
+        "exists": existing is not None,
+    }
+    if existing is None:
+        diff["action"] = "create"
+        diff["desired"] = desired
+    else:
+        current_normalized = normalize_merge_queue_for_comparison(existing)
+        desired_normalized = normalize_merge_queue_for_comparison(desired)
+        if current_normalized == desired_normalized:
+            diff["action"] = "none"
+            diff["message"] = "Merge-queue ruleset already matches desired configuration"
+        else:
+            diff["action"] = "update"
+            diff["current"] = current_normalized
+            diff["desired"] = desired_normalized
+            diff["ruleset_id"] = existing.get("id")
+    return diff
+
+
+def delete_ruleset_by_name(org: str, repo: str, ruleset_name: str) -> bool:
+    """Delete a ruleset by name. Returns True if a ruleset was removed."""
+    ruleset_id = get_existing_ruleset_id(org, repo, ruleset_name)
+    if not ruleset_id:
+        return False
+    result = run_gh(
+        ["api", "-X", "DELETE", f"repos/{org}/{repo}/rulesets/{ruleset_id}"],
+        check=False,
+    )
+    if result.returncode == 0:
+        log_info(f"  ✓ Removed ruleset '{ruleset_name}' (ID: {ruleset_id})")
+        return True
+    log_warn(f"  ⚠ Failed to remove '{ruleset_name}': {result.stderr}")
+    return False
+
+
+def apply_merge_queue_ruleset(org: str, repo: str, config: dict, bypass_actor_id: str) -> None:
+    """Create or update the org-managed merge-queue ruleset for a repository.
+
+    Also removes any leftover legacy plan-marshall-merge-queue ruleset so the
+    repo ends up with exactly one, bypass-carrying, merge-queue rule.
+    """
+    name = config["merge_queue"]["ruleset_name"]
+    log_info(f"Enabling merge queue on {org}/{repo}...")
+
+    payload_json = json.dumps(build_merge_queue_payload(config, bypass_actor_id))
+    existing_id = get_existing_ruleset_id(org, repo, name)
+
+    if existing_id:
+        log_info(f"  Updating existing '{name}' (ID: {existing_id})")
+        result = run_gh(
+            ["api", "-X", "PUT", f"repos/{org}/{repo}/rulesets/{existing_id}", "--input", "-"],
+            check=False,
+            input_data=payload_json,
+        )
+    else:
+        log_info(f"  Creating '{name}'")
+        result = run_gh(
+            ["api", "-X", "POST", f"repos/{org}/{repo}/rulesets", "--input", "-"],
+            check=False,
+            input_data=payload_json,
+        )
+
+    if result.returncode == 0:
+        log_info("  ✓ Done")
+    else:
+        log_warn(f"  ⚠ Failed: {result.stderr}")
+
+    # Migration: drop the legacy plan-marshall-branded queue if present.
+    delete_ruleset_by_name(org, repo, LEGACY_MERGE_QUEUE_NAME)
+
+
+def verify_merge_queue_ruleset(org: str, repo: str, config: dict, bypass_actor_id: str) -> bool:
+    """Verify the applied merge-queue ruleset matches the desired configuration."""
+    log_info("Verifying merge-queue ruleset...")
+
+    name = config["merge_queue"]["ruleset_name"]
+    existing = get_existing_ruleset(org, repo, name)
+    if existing is None:
+        log_error("  Could not fetch merge-queue ruleset for verification")
+        return False
+
+    desired = build_merge_queue_payload(config, bypass_actor_id)
+    current_normalized = normalize_merge_queue_for_comparison(existing)
+    desired_normalized = normalize_merge_queue_for_comparison(desired)
+
+    all_passed = True
+    for key in ["name", "enforcement"]:
+        if current_normalized.get(key) == desired_normalized.get(key):
+            log_info(f"  ✓ {key}: {current_normalized.get(key)}")
+        else:
+            log_error(f"  ✗ {key}: expected {desired_normalized.get(key)}, got {current_normalized.get(key)}")
+            all_passed = False
+
+    if current_normalized.get("conditions") == desired_normalized.get("conditions"):
+        log_info("  ✓ conditions: match")
+    else:
+        log_error("  ✗ conditions: mismatch")
+        all_passed = False
+
+    if current_normalized.get("bypass_actors") == desired_normalized.get("bypass_actors"):
+        log_info("  ✓ bypass_actors: match")
+    else:
+        log_error("  ✗ bypass_actors: mismatch")
+        all_passed = False
+
+    if current_normalized.get("rules") == desired_normalized.get("rules"):
+        log_info("  ✓ merge_queue rule: match")
+    else:
+        log_error("  ✗ merge_queue rule: mismatch")
+        log_error(f"    expected: {desired_normalized.get('rules')}")
+        log_error(f"    got: {current_normalized.get('rules')}")
+        all_passed = False
+
+    return all_passed
+
+
+def run_merge_queue_mode(args: argparse.Namespace, config: dict, org: str) -> None:
+    """Handle --enable-merge-queue / --disable-merge-queue.
+
+    Single-repo (--repo) honours --diff (enable only) and --apply. Batch mode
+    (no --repo) iterates config["merge_queue"]["merge_queue_repos"].
+    """
+    if "merge_queue" not in config:
+        log_error("Config has no 'merge_queue' block; cannot manage the merge queue")
+        sys.exit(1)
+
+    name = config["merge_queue"]["ruleset_name"]
+    repos = [args.repo] if args.repo else config["merge_queue"]["merge_queue_repos"]
+
+    if args.disable_merge_queue:
+        for repo in repos:
+            log_info(f"Disabling merge queue on {org}/{repo}...")
+            removed = delete_ruleset_by_name(org, repo, name)
+            removed = delete_ruleset_by_name(org, repo, LEGACY_MERGE_QUEUE_NAME) or removed
+            if not removed:
+                log_info(f"  (no merge-queue ruleset present on {org}/{repo})")
+        return
+
+    # Enable
+    bypass_actor_name = config["bypass_actor"]["name"]
+    config_app_id = config["bypass_actor"].get("app_id")
+    interactive = not args.diff
+    bypass_actor_id = get_bypass_actor_id(
+        org, bypass_actor_name, config_app_id=config_app_id, interactive=interactive
+    )
+
+    if args.repo and args.diff:
+        print(json.dumps(compute_merge_queue_diff(org, args.repo, config, bypass_actor_id), indent=2))
+        return
+
+    log_info(f"Org-managed merge queue: ruleset '{name}' (merge_method="
+             f"{config['merge_queue'].get('merge_method', 'SQUASH')}), bypass '{bypass_actor_name}'")
+    failed = False
+    for repo in repos:
+        apply_merge_queue_ruleset(org, repo, config, bypass_actor_id)
+        if not verify_merge_queue_ruleset(org, repo, config, bypass_actor_id):
+            log_error(f"Verification failed for {org}/{repo}")
+            failed = True
+    if failed:
+        sys.exit(1)
+
+
 def list_workflow_checks(org: str, repo: str) -> list[dict]:
     """List available workflow job names from recent runs.
 
@@ -501,6 +757,19 @@ Examples:
         metavar="N",
         help="Number of required approving reviews (0, 1, or 2)",
     )
+    parser.add_argument(
+        "--enable-merge-queue",
+        action="store_true",
+        help="Manage the org-managed merge-queue ruleset instead of branch protection. "
+        "With --repo: honours --diff/--apply. Without --repo: applies to all "
+        "merge_queue_repos in config. Also removes any legacy plan-marshall-merge-queue.",
+    )
+    parser.add_argument(
+        "--disable-merge-queue",
+        action="store_true",
+        help="Remove the merge-queue ruleset (and any legacy plan-marshall-merge-queue). "
+        "With --repo targets that repo; without --repo targets all merge_queue_repos.",
+    )
     return parser.parse_args()
 
 
@@ -530,8 +799,15 @@ def main() -> None:
     args = parse_args()
 
     # Validate argument combinations
-    if args.repo and not (args.diff or args.apply or args.list_checks):
-        log_error("When using --repo, you must specify --diff, --apply, or --list-checks")
+    merge_queue_mode = args.enable_merge_queue or args.disable_merge_queue
+
+    if args.enable_merge_queue and args.disable_merge_queue:
+        log_error("Cannot use --enable-merge-queue and --disable-merge-queue together")
+        sys.exit(1)
+
+    if args.repo and not (args.diff or args.apply or args.list_checks or merge_queue_mode):
+        log_error("When using --repo, you must specify --diff, --apply, --list-checks, "
+                  "--enable-merge-queue, or --disable-merge-queue")
         sys.exit(1)
 
     if sum([args.diff, args.apply, args.list_checks]) > 1:
@@ -561,6 +837,11 @@ def main() -> None:
             required_checks_override = [c.strip() for c in args.required_checks.split(",") if c.strip()]
 
     required_reviews_override = args.required_reviews
+
+    # Merge-queue management mode (independent of the branch-protection ruleset)
+    if merge_queue_mode:
+        run_merge_queue_mode(args, config, org)
+        return
 
     # List checks mode
     if args.repo and args.list_checks:

--- a/test/repo-admin/test_setup_branch_protection.py
+++ b/test/repo-admin/test_setup_branch_protection.py
@@ -258,3 +258,117 @@ class TestVerificationLogic:
 
         # Should exit with non-zero (either auth failure or repo not found)
         assert result.returncode != 0
+
+
+def _load_module():
+    """Import setup-branch-protection.py as a module for unit testing."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("setup_branch_protection", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMergeQueueConfig:
+    """Test the merge_queue block in config.json."""
+
+    def test_config_has_merge_queue_block(self):
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        assert "merge_queue" in config, "config.json should define a merge_queue block"
+
+    def test_merge_method_is_squash(self):
+        """merge_method must stay SQUASH to match the org merge policy."""
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        assert config["merge_queue"]["merge_method"] == "SQUASH"
+
+    def test_ruleset_name_is_org_managed(self):
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        assert config["merge_queue"]["ruleset_name"] == "main-merge-queue"
+
+    def test_merge_queue_repos_is_list(self):
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        assert isinstance(config["merge_queue"]["merge_queue_repos"], list)
+
+
+class TestMergeQueuePayloadBuild:
+    """Test the merge-queue ruleset payload construction."""
+
+    def test_payload_uses_release_bot_bypass(self):
+        """The queue ruleset must carry the release-bot bypass so releases work."""
+        module = _load_module()
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        payload = module.build_merge_queue_payload(config, "2753519")
+        assert payload["bypass_actors"] == [
+            {"actor_id": 2753519, "actor_type": "Integration", "bypass_mode": "always"}
+        ]
+
+    def test_payload_has_squash_merge_queue_rule(self):
+        module = _load_module()
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        payload = module.build_merge_queue_payload(config, "2753519")
+        rules = payload["rules"]
+        assert len(rules) == 1
+        assert rules[0]["type"] == "merge_queue"
+        assert rules[0]["parameters"]["merge_method"] == "SQUASH"
+
+    def test_payload_targets_main(self):
+        module = _load_module()
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        payload = module.build_merge_queue_payload(config, "2753519")
+        assert payload["conditions"]["ref_name"]["include"] == ["refs/heads/main"]
+        assert payload["enforcement"] == "active"
+
+    def test_normalize_roundtrip_matches(self):
+        """A payload normalizes equal to itself (diff would report 'none')."""
+        module = _load_module()
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        payload = module.build_merge_queue_payload(config, "2753519")
+        assert (
+            module.normalize_merge_queue_for_comparison(payload)
+            == module.normalize_merge_queue_for_comparison(payload)
+        )
+
+    def test_legacy_queue_name_constant(self):
+        module = _load_module()
+        assert module.LEGACY_MERGE_QUEUE_NAME == "plan-marshall-merge-queue"
+
+
+class TestMergeQueueArgValidation:
+    """Test CLI validation for the merge-queue flags."""
+
+    def test_enable_and_disable_mutually_exclusive(self, temp_dir):
+        config = temp_dir / "config.json"
+        config.write_text(json.dumps({
+            "organization": "test",
+            "repositories": [],
+            "bypass_actor": {"name": "test-app", "type": "Integration", "app_id": "1"},
+            "ruleset": {
+                "name": "test", "enforcement": "active", "branch_pattern": "main",
+                "rules": {
+                    "require_pull_request": {
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": False,
+                        "require_last_push_approval": False,
+                    },
+                    "require_status_checks": {
+                        "strict_required_status_checks_policy": False,
+                        "do_not_enforce_on_create": False,
+                        "required_checks": [],
+                    },
+                },
+            },
+        }))
+        result = run_script(
+            SCRIPT_PATH, config, "--enable-merge-queue", "--disable-merge-queue"
+        )
+        assert result.returncode != 0
+        assert "together" in result.stderr.lower()

--- a/workflow-scripts/consumer_update_utils.py
+++ b/workflow-scripts/consumer_update_utils.py
@@ -92,9 +92,18 @@ def read_auto_merge_config(repo_dir: Path) -> dict:
 def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
     """Enable GitHub auto-merge on the PR (async, returns immediately).
 
+    Queue-safe: never passes ``--delete-branch``. The org sets
+    ``delete_branch_on_merge=true`` (repo-settings), so the head branch is
+    removed automatically, and a repo with a merge queue enabled *rejects*
+    ``--delete-branch``. With a merge queue, ``--auto`` enqueues the PR; without
+    one, it merges once required checks pass.
+
     When the PR is already in "clean" status (all required checks passed or
-    skipped), GitHub rejects ``--auto`` with a "clean status" error.  In that
-    case we fall back to merging the PR directly.
+    skipped) and no merge queue is configured, GitHub rejects ``--auto`` with a
+    "clean status" error. In that case we fall back to a plain squash merge
+    (still no ``--delete-branch``). This fallback path is only reached when no
+    merge queue is present — with a queue, ``--auto`` always succeeds by
+    enqueuing.
 
     Args:
         full_repo: Full repo name (e.g. "cuioss/cui-java-tools")
@@ -105,7 +114,7 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
     """
     print(f"Auto-merge: enabling for {pr_url}")
     result = run_gh(
-        ["pr", "merge", "--auto", "--squash", "--delete-branch", pr_url],
+        ["pr", "merge", "--auto", "--squash", pr_url],
         check=False,
     )
     if result.returncode == 0:
@@ -113,12 +122,12 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
         return True
 
     # When all required checks are already satisfied (e.g. workflow-only
-    # changes where build checks are skipped), GitHub returns a "clean status"
-    # error.  Fall back to an immediate merge.
+    # changes where build checks are skipped) and no merge queue is configured,
+    # GitHub returns a "clean status" error.  Fall back to an immediate merge.
     if "clean status" in result.stderr:
         print("PR already in clean status, merging directly...")
         merge_result = run_gh(
-            ["pr", "merge", "--squash", "--delete-branch", pr_url],
+            ["pr", "merge", "--squash", pr_url],
             check=False,
         )
         if merge_result.returncode == 0:

--- a/workflow-scripts/verify-consumer-prs.py
+++ b/workflow-scripts/verify-consumer-prs.py
@@ -266,8 +266,9 @@ def main() -> int:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=300,
-        help="Maximum seconds to wait for PRs to merge (default: 300)",
+        default=900,
+        help="Maximum seconds to wait for PRs to merge (default: 900). Allows for "
+        "merge-queue latency on repos where the queue is enabled.",
     )
     parser.add_argument(
         "--poll-interval",


### PR DESCRIPTION
## Problem

A per-developer, plan-marshall-branded merge-queue ruleset (`plan-marshall-merge-queue`) had been created on 6 repos by plan-marshall's steward. It made the merge queue **mandatory on `main` with no bypass actors**, which broke the release workflow: the release job's direct push of the release commit + tag to `main` (relying on the `cuioss-release-bot` bypass in `main-branch-protection`) was rejected with `GH013 — changes must be made through the merge queue`. This surfaced during the `cui-parent-pom` 1.5.2 release (artifacts published to Central, but tag + GitHub release never created).

The org's canonical `branch-protection/` tooling had **zero merge-queue awareness**, so the two rule systems were split-brained.

## Solution

Re-own the merge queue as an **org-managed, opt-in** ruleset (`main-merge-queue`), configured through `branch-protection/`:

- **`config.json`** — `merge_queue` block: `merge_method: SQUASH` (matches the org squash policy), `grouping_strategy: ALLGREEN`, and an opt-in `merge_queue_repos` list (the 6 repos that had the queue).
- **`setup-branch-protection.py`** — `--enable-merge-queue` / `--disable-merge-queue`. The queue ruleset carries the **same `cuioss-release-bot` bypass** as `main-branch-protection`, so releases keep working. Enabling also removes any leftover legacy `plan-marshall-merge-queue`. Idempotent diff/apply/verify.
- **`consumer_update_utils.auto_merge_pr()`** — queue-safe: drops `--delete-branch` (redundant with org-wide `delete_branch_on_merge=true`, and rejected under a merge queue) and its direct-merge fallback's `--delete-branch`. `gh pr merge --auto --squash` works with and without a queue.
- **`verify-consumer-prs.py` + release workflow** — bump propagation verify timeout 300s → 900s for merge-queue latency.
- **Tests** — merge-queue payload (release-bot bypass, SQUASH rule, target main), config schema, and flag validation. 27/27 pass.

## Bot compatibility notes

- **Dependabot auto-merge** (`gh pr merge --auto --squash`) already respects a merge queue — no change needed.
- **Queued repos** must also trigger their build caller workflow on `merge_group` or queue entries stall; that per-repo `maven.yml` change is rolled out alongside this.

## Rollout (performed with this branch's script)

- Delete `plan-marshall-merge-queue` from all 6 repos.
- Create `main-merge-queue` (with release-bot bypass) on the 6 opt-in repos.
- Add `on: merge_group:` to `maven.yml` in the repos lacking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional organization-managed merge queue support for configured repositories, including commands to enable, disable, preview, and apply settings.
  * Added migration handling for legacy merge queue configurations.

* **Improvements**
  * Updated automated merges to work reliably with merge queues and branch-deletion settings.
  * Increased verification wait time to accommodate merge queue processing.

* **Documentation**
  * Added setup requirements, configuration details, and usage instructions for merge queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->