### PR TITLE
release: prepare 0.10.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.10.1
+  current-version: 0.10.2
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bumps `current-version` to 0.10.2. Dispatching the Release workflow after merge tags v0.10.2, updates workflow references, and propagates the new SHA to consumers — carrying the queue-safe propagation auto-merge and 900s verify timeout from #182.