### PR TITLE
fix(release): make consumer PR auto-merge merge-queue-safe

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -291,6 +291,8 @@ jobs:
             jq -r '.[] |
               if .status == "pr_auto_merge_enabled" then
                 "| " + .repo + " | :hourglass: Auto-merge enabled | [PR](" + (.pr_url // "-") + ") |"
+              elif .status == "pr_auto_merge_failed" then
+                "| " + .repo + " | :x: Auto-merge FAILED (needs manual merge) | [PR](" + (.pr_url // "-") + ") |"
               elif .status == "pr_created" then
                 "| " + .repo + " | :arrow_right: PR Created | [PR](" + (.pr_url // "-") + ") |"
               elif .status == "no_changes" then

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -24,15 +24,30 @@ on:
         required: false
         type: string
         default: './pw verify'
+      skip-on-docs-only:
+        description: >-
+          Skip verify when only documentation/config files changed (footprint
+          filter). Opt-in — the default (false) preserves the current
+          always-verify behavior; each consumer enables it explicitly, matching
+          the maven reusable's toggle. Never skips a merge_group run.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  # Decide whether this run should proceed. Skips a push-triggered run when an
-  # open PR already covers the same branch — the PR's own run verifies that commit,
-  # so the push run is redundant. A push to a branch with no open PR still runs,
-  # and the default branch always runs.
+  # Decide whether this run should proceed, from two independent skip reasons:
+  #   1. Footprint skip (opt-in via skip-on-docs-only): every changed path is a
+  #      non-building doc/config file, so the heavy verify is unnecessary.
+  #   2. Push-dedup skip: a push whose commit is already covered by an open PR
+  #      (the PR's own run verifies that commit), so the push run is redundant.
+  # Either reason can skip. A merge_group run always builds (no reliable diff
+  # base — the merge-queue must verify the full merge result), and the default
+  # branch always runs unless the footprint skip applies. The `conclusion` job
+  # reports SUCCESS when the gate deliberately skips verify, which keeps a
+  # skipped run merge-queue-safe.
   gate:
     runs-on: ubuntu-latest
     permissions:
@@ -41,6 +56,47 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
+      # Footprint filter (opt-in via skip-on-docs-only): decide whether any
+      # changed path is a building file. Skipped entirely on merge_group — a
+      # merge-queue run has no reliable diff base and must build the full merge
+      # result. The paths-filter step is continue-on-error so a diff-base error
+      # fails OPEN: `footprint.outcome` is then not 'success' and the decide step
+      # runs the verification rather than skipping it.
+      - name: Checkout
+        if: ${{ inputs.skip-on-docs-only && github.event_name != 'merge_group' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build paths-filter spec
+        id: build-filter
+        if: ${{ inputs.skip-on-docs-only && github.event_name != 'merge_group' }}
+        run: |
+          {
+            echo 'spec<<EOF'
+            echo 'buildable:'
+            echo "  - '!**/*.adoc'"
+            echo "  - '!**/*.md'"
+            echo "  - '!doc/**'"
+            echo "  - '!.plan/**'"
+            echo "  - '!.claude/**'"
+            echo "  - '!LICENSE'"
+            echo "  - '!NOTICE'"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # predicate-quantifier MUST be 'every': the spec is all-negation, so
+      # dorny's default 'some' would OR the patterns and any non-.adoc file would
+      # match '!**/*.adoc', leaving 'buildable' always true. 'every' ANDs them,
+      # so a path counts as buildable only when it matches none of the ignore
+      # globs — i.e. buildable == 'false' iff EVERY changed path is non-building.
+      - name: Footprint filter
+        id: footprint
+        if: ${{ inputs.skip-on-docs-only && github.event_name != 'merge_group' }}
+        continue-on-error: true
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          predicate-quantifier: 'every'
+          filters: ${{ steps.build-filter.outputs.spec }}
+
       - name: Decide whether to run
         id: decide
         env:
@@ -49,7 +105,24 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SKIP_ON_DOCS_ONLY: ${{ inputs.skip-on-docs-only }}
+          FOOTPRINT_OUTCOME: ${{ steps.footprint.outcome }}
+          BUILDABLE: ${{ steps.footprint.outputs.buildable }}
         run: |
+          # A merge-queue run has no reliable diff base and must build the full
+          # merge result — always run.
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            echo "merge_group run — building the full merge result"
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Footprint skip (independent of the push-dedup skip below — either can
+          # skip). Fail-open: skip ONLY when the paths-filter ran cleanly
+          # (outcome 'success') AND reported no buildable paths. Any filter or
+          # diff-base error (outcome != 'success') falls through and runs verify.
+          if [[ "$SKIP_ON_DOCS_ONLY" == "true" && "$FOOTPRINT_OUTCOME" == "success" && "$BUILDABLE" == "false" ]]; then
+            echo "Only non-building (docs/config) files changed — skipping verify"
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           # Non-push events (pull_request, workflow_dispatch, …) always run.
           if [[ "$EVENT_NAME" != "push" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"; exit 0

--- a/test/workflow/test_consumer_update_utils.py
+++ b/test/workflow/test_consumer_update_utils.py
@@ -22,6 +22,7 @@ class TestStatusConstants:
 
     def test_status_constants_exist(self):
         assert utils.STATUS_PR_AUTO_MERGE_ENABLED == "pr_auto_merge_enabled"
+        assert utils.STATUS_PR_AUTO_MERGE_FAILED == "pr_auto_merge_failed"
         assert utils.STATUS_PR_CREATED == "pr_created"
         assert utils.STATUS_NO_CHANGES == "no_changes"
         assert utils.STATUS_ERROR == "error"
@@ -244,6 +245,36 @@ class TestAutoMergePr:
         mock_gh.side_effect = [
             MagicMock(returncode=1, stderr="clean status error"),
             MagicMock(returncode=1, stderr="Merge conflict"),
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is False
+        assert mock_gh.call_count == 2
+
+    @patch("consumer_update_utils.run_gh")
+    def test_merge_queue_retries_without_method(self, mock_gh):
+        """On a merge-queue repo, --squash is rejected; retry --auto without a method."""
+        mock_gh.side_effect = [
+            # First call: --auto --squash rejected because a merge queue is enabled
+            MagicMock(
+                returncode=1,
+                stderr="X Cannot use `-d` or `--delete-branch` when merge queue enabled",
+            ),
+            # Second call: --auto (no method) enqueues successfully
+            MagicMock(returncode=0),
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is True
+        assert mock_gh.call_count == 2
+        second_call_args = mock_gh.call_args_list[1][0][0]
+        assert "--auto" in second_call_args
+        assert "--squash" not in second_call_args
+
+    @patch("consumer_update_utils.run_gh")
+    def test_merge_queue_retry_also_fails(self, mock_gh):
+        """When the merge-queue enqueue retry also fails, return False."""
+        mock_gh.side_effect = [
+            MagicMock(returncode=1, stderr="merge strategy for main is set by the merge queue"),
+            MagicMock(returncode=1, stderr="not mergeable"),
         ]
         result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
         assert result is False

--- a/workflow-scripts/consumer_update_utils.py
+++ b/workflow-scripts/consumer_update_utils.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 # Result status constants
 STATUS_PR_AUTO_MERGE_ENABLED = "pr_auto_merge_enabled"
+STATUS_PR_AUTO_MERGE_FAILED = "pr_auto_merge_failed"
 STATUS_PR_CREATED = "pr_created"
 STATUS_NO_CHANGES = "no_changes"
 STATUS_ERROR = "error"
@@ -95,22 +96,28 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
     Queue-safe: never passes ``--delete-branch``. The org sets
     ``delete_branch_on_merge=true`` (repo-settings), so the head branch is
     removed automatically, and a repo with a merge queue enabled *rejects*
-    ``--delete-branch``. With a merge queue, ``--auto`` enqueues the PR; without
-    one, it merges once required checks pass.
+    ``--delete-branch``.
 
-    When the PR is already in "clean" status (all required checks passed or
-    skipped) and no merge queue is configured, GitHub rejects ``--auto`` with a
-    "clean status" error. In that case we fall back to a plain squash merge
-    (still no ``--delete-branch``). This fallback path is only reached when no
-    merge queue is present — with a queue, ``--auto`` always succeeds by
-    enqueuing.
+    The merge method depends on whether the base branch has a merge queue:
+
+    * **No merge queue** — ``gh`` requires an explicit method, so we pass
+      ``--squash``. When every required check is already green (e.g.
+      workflow-only changes where build checks are skipped), ``--auto`` is
+      rejected with a "clean status" error and we fall back to an immediate
+      squash merge.
+    * **Merge queue enabled** — the queue's ruleset owns the merge method (and
+      branch deletion), so ``gh`` *rejects* an explicit ``--squash`` with
+      ``Cannot use ... when merge queue enabled``. We detect that rejection and
+      retry ``--auto`` *without* a method flag, which enqueues the PR (the queue
+      re-tests against the latest base and merges with its configured method).
 
     Args:
         full_repo: Full repo name (e.g. "cuioss/cui-java-tools")
         pr_url: URL of the PR to merge
 
     Returns:
-        True if auto-merge was enabled or the PR was merged, False otherwise.
+        True if auto-merge was enabled / the PR was enqueued or merged, else
+        False.
     """
     print(f"Auto-merge: enabling for {pr_url}")
     result = run_gh(
@@ -121,10 +128,28 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
         print(f"Auto-merge enabled: {pr_url}")
         return True
 
+    stderr = result.stderr or ""
+    low = stderr.lower()
+
+    # Merge-queue repo: the queue's ruleset dictates the merge method, so gh
+    # rejects the explicit --squash ("Cannot use ... when merge queue enabled").
+    # Retry --auto without a method flag so the PR is enqueued.
+    if "merge queue" in low:
+        print("Merge queue enabled — enqueuing without an explicit merge method...")
+        queued = run_gh(
+            ["pr", "merge", "--auto", pr_url],
+            check=False,
+        )
+        if queued.returncode == 0:
+            print(f"Auto-merge (merge queue) enabled: {pr_url}")
+            return True
+        print(f"::warning::Failed to enqueue on merge-queue repo: {queued.stderr}")
+        return False
+
     # When all required checks are already satisfied (e.g. workflow-only
     # changes where build checks are skipped) and no merge queue is configured,
     # GitHub returns a "clean status" error.  Fall back to an immediate merge.
-    if "clean status" in result.stderr:
+    if "clean status" in low:
         print("PR already in clean status, merging directly...")
         merge_result = run_gh(
             ["pr", "merge", "--squash", pr_url],
@@ -135,7 +160,7 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
             return True
         print(f"::warning::Direct merge also failed: {merge_result.stderr}")
 
-    print(f"::warning::Failed to enable auto-merge: {result.stderr}")
+    print(f"::warning::Failed to enable auto-merge: {stderr}")
     return False
 
 
@@ -334,7 +359,11 @@ def create_pr_and_auto_merge(
     if auto_merge_config["enabled"]:
         print(f"Auto-merge enabled for {full_repo}")
         enabled = auto_merge_pr(full_repo, pr_url)
-        status = STATUS_PR_AUTO_MERGE_ENABLED if enabled else STATUS_PR_CREATED
+        # A failed enable (e.g. an unhandled merge-queue rejection) must be a
+        # distinct status, not STATUS_PR_CREATED — the latter is the legitimate
+        # "auto-merge disabled by config" state and would silently mask a PR
+        # that was created but never enqueued.
+        status = STATUS_PR_AUTO_MERGE_ENABLED if enabled else STATUS_PR_AUTO_MERGE_FAILED
     else:
         print(f"Auto-merge disabled for {full_repo}, leaving PR open")
         status = STATUS_PR_CREATED

--- a/workflow-scripts/verify-consumer-prs.py
+++ b/workflow-scripts/verify-consumer-prs.py
@@ -145,6 +145,20 @@ def verify_prs(results_file: str, timeout: int, poll_interval: int = 30) -> list
     with open(results_file, encoding="utf-8") as f:
         results = json.loads(f.read())
 
+    # PRs where enabling auto-merge FAILED (e.g. a merge-queue repo whose
+    # enqueue could not be completed) are never polled — they will never merge
+    # on their own. Surface them directly as failures so a stuck propagation PR
+    # is never silently dropped from the report.
+    auto_merge_failed = [
+        {
+            "repo": r["repo"],
+            "pr_url": r.get("pr_url"),
+            "final_status": "auto_merge_failed",
+        }
+        for r in results
+        if r.get("status") == "pr_auto_merge_failed"
+    ]
+
     # Filter to only PRs that have auto-merge enabled
     prs = [
         r
@@ -153,6 +167,8 @@ def verify_prs(results_file: str, timeout: int, poll_interval: int = 30) -> list
     ]
 
     if not prs:
+        if auto_merge_failed:
+            return auto_merge_failed
         print("No PRs with auto-merge enabled to verify.")
         return []
 
@@ -207,7 +223,7 @@ def verify_prs(results_file: str, timeout: int, poll_interval: int = 30) -> list
                 {"repo": pr["repo"], "pr_url": pr["pr_url"], "final_status": "pending"}
             )
 
-    return final_results
+    return auto_merge_failed + final_results
 
 
 def print_summary(final_results: list[dict]) -> None:
@@ -219,6 +235,7 @@ def print_summary(final_results: list[dict]) -> None:
         "merged": ":white_check_mark: Merged",
         "pending": ":hourglass: Auto-merge pending",
         "stuck_no_push": ":warning: Stuck — no push event",
+        "auto_merge_failed": ":x: Auto-merge never enabled (needs manual merge)",
         "failed": ":x: Failed",
         "closed": ":x: Closed",
     }
@@ -286,8 +303,10 @@ def main() -> int:
     final_results = verify_prs(args.results_file, args.timeout, args.poll_interval)
     print_summary(final_results)
 
-    # Return non-zero if any PR failed
-    failed = any(r["final_status"] == "failed" for r in final_results)
+    # Return non-zero if any PR failed or never got auto-merge enabled
+    failed = any(
+        r["final_status"] in ("failed", "auto_merge_failed") for r in final_results
+    )
     return 1 if failed else 0
 
 


### PR DESCRIPTION
## Problem

The dependency-propagation step (`consumer_update_utils.py:auto_merge_pr`) ran `gh pr merge --auto --squash` unconditionally. On a consumer repo with an **active merge queue**, the queue's ruleset owns the merge method (and branch deletion), so `gh` rejects the explicit `--squash`:

```
X Cannot use `-d` or `--delete-branch` when merge queue enabled
```

The only fallback matched `"clean status"`, so the call just warned and returned `False` — the PR was **created but never enqueued** and sat open indefinitely.

Observed during the `cui-parent-pom` 1.5.3 propagation: the 14 consumers **without** a merge queue merged fine; the two **with** a merge queue (`TokenSheriff#585`, `cui-open-rewrite#111`) were left stuck. `verify-consumer-prs.py` then filtered them out (it only checks `pr_auto_merge_enabled`), so the release reported success and the failure was invisible.

## Fix

- **`auto_merge_pr`**: on a `"merge queue"` rejection, retry `gh pr merge --auto` **without** a method flag so the PR is enqueued (the queue re-tests and merges with its configured method). The no-queue `--squash` + `clean status` fallback is unchanged. Docstring corrected (it previously claimed the opposite).
- **Distinct failure status** `pr_auto_merge_failed` instead of `pr_created`, so a failed enable is no longer indistinguishable from the legitimate "auto-merge disabled by config" state.
- **`verify-consumer-prs.py`**: surfaces `pr_auto_merge_failed` PRs as failures and exits non-zero, so a stuck propagation PR fails the release loudly.
- **`reusable-maven-release.yml`**: renders `pr_auto_merge_failed` as an error row in the propagation summary.

## Tests

Added merge-queue retry coverage (rejection→retry-without-method success, and retry-also-fails). Full `test/workflow` suite passes (49 passed); ruff clean.

## Note

The two already-stuck PRs are being unstuck manually out-of-band.