### PR TITLE
release: prepare 0.11.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.10.2
+  current-version: 0.11.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump `current-version` to 0.11.0 for release.

Ships:
- fix(release): merge-queue-safe consumer PR auto-merge (#184)
- feat(pyproject-verify): opt-in footprint (docs-only) skip in the reusable gate (#184)

Dispatch the Release workflow after merge to tag `v0.11.0`; consumers pin to that tag/SHA.