### PR TITLE
fix(release): probe live merge-queue ruleset instead of guessing the merge method

### DIFF
--- a/test/workflow/test_consumer_update_utils.py
+++ b/test/workflow/test_consumer_update_utils.py
@@ -207,78 +207,112 @@ class TestCloseStalePrs:
         assert closed == []
 
 
+# Probe result helpers: base_branch_has_merge_queue runs `gh api ...` first and
+# reads returncode + stdout ('true'/'false'/other).
+def _probe(has_queue):
+    """A mock gh-api result for base_branch_has_merge_queue: True/False/None."""
+    if has_queue is None:
+        return MagicMock(returncode=1, stdout="", stderr="api error")
+    return MagicMock(returncode=0, stdout="true\n" if has_queue else "false\n")
+
+
+class TestBaseBranchHasMergeQueue:
+    """Test the deterministic merge-queue probe."""
+
+    @patch("consumer_update_utils.run_gh")
+    def test_true(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="true\n")
+        assert utils.base_branch_has_merge_queue("cuioss/repo") is True
+
+    @patch("consumer_update_utils.run_gh")
+    def test_false(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="false\n")
+        assert utils.base_branch_has_merge_queue("cuioss/repo") is False
+
+    @patch("consumer_update_utils.run_gh")
+    def test_none_on_api_error(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=1, stdout="", stderr="boom")
+        assert utils.base_branch_has_merge_queue("cuioss/repo") is None
+
+    @patch("consumer_update_utils.run_gh")
+    def test_none_on_unparseable(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="not-a-bool")
+        assert utils.base_branch_has_merge_queue("cuioss/repo") is None
+
+
 class TestAutoMergePr:
-    """Test auto_merge_pr function."""
+    """Test auto_merge_pr function (probe-first)."""
 
     @patch("consumer_update_utils.run_gh")
-    def test_enables_auto_merge(self, mock_gh):
-        mock_gh.return_value = MagicMock(returncode=0)
-        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
-        assert result is True
-        mock_gh.assert_called_once()
-
-    @patch("consumer_update_utils.run_gh")
-    def test_returns_false_on_generic_failure(self, mock_gh):
-        mock_gh.return_value = MagicMock(returncode=1, stderr="Permission denied")
-        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
-        assert result is False
-
-    @patch("consumer_update_utils.run_gh")
-    def test_falls_back_to_direct_merge_on_clean_status(self, mock_gh):
-        """When PR is already in clean status, fall back to direct merge."""
+    def test_no_queue_enables_auto_merge_with_squash(self, mock_gh):
         mock_gh.side_effect = [
-            # First call: --auto fails with clean status
-            MagicMock(returncode=1, stderr="GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)"),
-            # Second call: direct merge succeeds
-            MagicMock(returncode=0),
+            _probe(False),           # probe: no queue
+            MagicMock(returncode=0),  # pr merge --auto --squash
         ]
         result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
         assert result is True
         assert mock_gh.call_count == 2
-        # Second call should NOT have --auto
-        second_call_args = mock_gh.call_args_list[1][0][0]
-        assert "--auto" not in second_call_args
+        merge_args = mock_gh.call_args_list[1][0][0]
+        assert "--auto" in merge_args and "--squash" in merge_args
 
     @patch("consumer_update_utils.run_gh")
-    def test_clean_status_fallback_also_fails(self, mock_gh):
-        """When both auto-merge and direct merge fail."""
+    def test_merge_queue_enqueues_without_method(self, mock_gh):
         mock_gh.side_effect = [
-            MagicMock(returncode=1, stderr="clean status error"),
-            MagicMock(returncode=1, stderr="Merge conflict"),
-        ]
-        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
-        assert result is False
-        assert mock_gh.call_count == 2
-
-    @patch("consumer_update_utils.run_gh")
-    def test_merge_queue_retries_without_method(self, mock_gh):
-        """On a merge-queue repo, --squash is rejected; retry --auto without a method."""
-        mock_gh.side_effect = [
-            # First call: --auto --squash rejected because a merge queue is enabled
-            MagicMock(
-                returncode=1,
-                stderr="X Cannot use `-d` or `--delete-branch` when merge queue enabled",
-            ),
-            # Second call: --auto (no method) enqueues successfully
-            MagicMock(returncode=0),
+            _probe(True),            # probe: queue present
+            MagicMock(returncode=0),  # pr merge --auto (no method)
         ]
         result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
         assert result is True
         assert mock_gh.call_count == 2
-        second_call_args = mock_gh.call_args_list[1][0][0]
-        assert "--auto" in second_call_args
-        assert "--squash" not in second_call_args
+        merge_args = mock_gh.call_args_list[1][0][0]
+        assert "--auto" in merge_args and "--squash" not in merge_args
 
     @patch("consumer_update_utils.run_gh")
-    def test_merge_queue_retry_also_fails(self, mock_gh):
-        """When the merge-queue enqueue retry also fails, return False."""
+    def test_merge_queue_enqueue_failure_returns_false(self, mock_gh):
         mock_gh.side_effect = [
-            MagicMock(returncode=1, stderr="merge strategy for main is set by the merge queue"),
+            _probe(True),
             MagicMock(returncode=1, stderr="not mergeable"),
         ]
         result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
         assert result is False
         assert mock_gh.call_count == 2
+
+    @patch("consumer_update_utils.run_gh")
+    def test_returns_false_on_generic_failure(self, mock_gh):
+        mock_gh.side_effect = [
+            _probe(False),
+            MagicMock(returncode=1, stderr="Permission denied"),
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is False
+
+    @patch("consumer_update_utils.run_gh")
+    def test_falls_back_to_direct_merge_on_clean_status(self, mock_gh):
+        """No queue + already-clean status: fall back to a direct squash merge."""
+        mock_gh.side_effect = [
+            _probe(False),
+            MagicMock(returncode=1, stderr="GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)"),
+            MagicMock(returncode=0),  # direct merge succeeds
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is True
+        assert mock_gh.call_count == 3
+        third_call_args = mock_gh.call_args_list[2][0][0]
+        assert "--auto" not in third_call_args
+
+    @patch("consumer_update_utils.run_gh")
+    def test_probe_undeterminable_retries_on_merge_queue_error(self, mock_gh):
+        """Probe fails (None); the no-queue attempt hits a queue error → retry --auto."""
+        mock_gh.side_effect = [
+            _probe(None),  # probe undeterminable
+            MagicMock(returncode=1, stderr="X Cannot use `--delete-branch` when merge queue enabled"),
+            MagicMock(returncode=0),  # retry --auto (no method) enqueues
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is True
+        assert mock_gh.call_count == 3
+        retry_args = mock_gh.call_args_list[2][0][0]
+        assert "--auto" in retry_args and "--squash" not in retry_args
 
 
 class TestOutputResult:

--- a/workflow-scripts/consumer_update_utils.py
+++ b/workflow-scripts/consumer_update_utils.py
@@ -90,7 +90,38 @@ def read_auto_merge_config(repo_dir: Path) -> dict:
     return config
 
 
-def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
+def base_branch_has_merge_queue(full_repo: str, branch: str = "main") -> bool | None:
+    """Probe whether ``branch`` has an active merge queue.
+
+    Reads the branch's *effective* ruleset via the GitHub REST API
+    (``GET /repos/{repo}/rules/branches/{branch}``), which lists every rule in
+    force on the branch, and reports whether any is a ``merge_queue`` rule. This
+    is the ground truth GitHub itself enforces, so it can never drift out of sync
+    the way a hand-maintained per-repo config flag would.
+
+    Returns:
+        ``True``  — the branch has an active merge queue.
+        ``False`` — no merge queue (the endpoint returned a rule list without
+                    one, including the empty list for a repo with no rulesets).
+        ``None``  — undeterminable (API error / auth / unparseable output). The
+                    caller falls back to the stderr-adaptive path.
+    """
+    result = run_gh(
+        ["api", f"repos/{full_repo}/rules/branches/{branch}",
+         "--jq", 'any(.[]; .type == "merge_queue")'],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip()
+    if out == "true":
+        return True
+    if out == "false":
+        return False
+    return None
+
+
+def auto_merge_pr(full_repo: str, pr_url: str, base_branch: str = "main") -> bool:
     """Enable GitHub auto-merge on the PR (async, returns immediately).
 
     Queue-safe: never passes ``--delete-branch``. The org sets
@@ -98,32 +129,49 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
     removed automatically, and a repo with a merge queue enabled *rejects*
     ``--delete-branch``.
 
-    The merge method depends on whether the base branch has a merge queue:
+    The merge method depends on whether ``base_branch`` has a merge queue, which
+    is **probed deterministically** up front (:func:`base_branch_has_merge_queue`
+    reads the branch's effective ruleset — the same authority the queue
+    enforces, so it cannot disagree with reality):
 
-    * **No merge queue** — ``gh`` requires an explicit method, so we pass
+    * **Merge queue** — the queue's ruleset owns the merge method (and branch
+      deletion), so ``gh`` rejects an explicit method flag. Enqueue with
+      ``--auto`` and no method; the queue re-tests against the latest base and
+      merges with its configured method.
+    * **No merge queue** — ``gh`` requires an explicit method, so pass
       ``--squash``. When every required check is already green (e.g.
       workflow-only changes where build checks are skipped), ``--auto`` is
       rejected with a "clean status" error and we fall back to an immediate
       squash merge.
-    * **Merge queue enabled** — the queue's ruleset owns the merge method (and
-      branch deletion), so ``gh`` *rejects* an explicit ``--squash`` with
-      ``Cannot use ... when merge queue enabled``. We detect that rejection and
-      retry ``--auto`` *without* a method flag, which enqueues the PR (the queue
-      re-tests against the latest base and merges with its configured method).
+    * **Probe undeterminable** (``None``) — try the no-queue form and adapt on
+      the stderr: a "merge queue" rejection means the repo did have a queue
+      after all, so retry ``--auto`` without a method flag. This preserves the
+      previous self-correcting behavior when the probe cannot be evaluated.
 
     Args:
         full_repo: Full repo name (e.g. "cuioss/cui-java-tools")
         pr_url: URL of the PR to merge
+        base_branch: Base branch the PR targets (default "main")
 
     Returns:
         True if auto-merge was enabled / the PR was enqueued or merged, else
         False.
     """
     print(f"Auto-merge: enabling for {pr_url}")
-    result = run_gh(
-        ["pr", "merge", "--auto", "--squash", pr_url],
-        check=False,
-    )
+    has_queue = base_branch_has_merge_queue(full_repo, base_branch)
+
+    # Merge-queue repo: enqueue without a method flag (the queue dictates it).
+    if has_queue is True:
+        print("Merge queue detected — enqueuing without an explicit merge method...")
+        queued = run_gh(["pr", "merge", "--auto", pr_url], check=False)
+        if queued.returncode == 0:
+            print(f"Auto-merge (merge queue) enabled: {pr_url}")
+            return True
+        print(f"::warning::Failed to enqueue on merge-queue repo: {queued.stderr}")
+        return False
+
+    # No queue (or probe undeterminable): gh requires an explicit method.
+    result = run_gh(["pr", "merge", "--auto", "--squash", pr_url], check=False)
     if result.returncode == 0:
         print(f"Auto-merge enabled: {pr_url}")
         return True
@@ -131,30 +179,23 @@ def auto_merge_pr(full_repo: str, pr_url: str) -> bool:
     stderr = result.stderr or ""
     low = stderr.lower()
 
-    # Merge-queue repo: the queue's ruleset dictates the merge method, so gh
-    # rejects the explicit --squash ("Cannot use ... when merge queue enabled").
-    # Retry --auto without a method flag so the PR is enqueued.
+    # Safety net for has_queue is None (probe failed) but the repo DID have a
+    # queue: gh rejects the explicit --squash — retry --auto without a method.
     if "merge queue" in low:
         print("Merge queue enabled — enqueuing without an explicit merge method...")
-        queued = run_gh(
-            ["pr", "merge", "--auto", pr_url],
-            check=False,
-        )
+        queued = run_gh(["pr", "merge", "--auto", pr_url], check=False)
         if queued.returncode == 0:
             print(f"Auto-merge (merge queue) enabled: {pr_url}")
             return True
         print(f"::warning::Failed to enqueue on merge-queue repo: {queued.stderr}")
         return False
 
-    # When all required checks are already satisfied (e.g. workflow-only
-    # changes where build checks are skipped) and no merge queue is configured,
-    # GitHub returns a "clean status" error.  Fall back to an immediate merge.
+    # No queue + all required checks already satisfied (e.g. workflow-only
+    # changes where build checks are skipped): gh returns a "clean status"
+    # error. Fall back to an immediate merge.
     if "clean status" in low:
         print("PR already in clean status, merging directly...")
-        merge_result = run_gh(
-            ["pr", "merge", "--squash", pr_url],
-            check=False,
-        )
+        merge_result = run_gh(["pr", "merge", "--squash", pr_url], check=False)
         if merge_result.returncode == 0:
             print(f"PR merged directly: {pr_url}")
             return True


### PR DESCRIPTION
Follow-up to #184. Replaces the stderr-adaptive merge-method handling in `auto_merge_pr` with a **deterministic, drift-proof probe** of the target branch's live ruleset.

## Why

#184 detected merge-queue repos by catching gh's `--squash`-rejection on stderr and retrying. That works and is self-correcting, but it (a) depends on gh's error wording (which we saw vary between runs) and (b) pays a failed first attempt. The obvious alternative — a per-repo `project.yml` knob declaring `merge-queue: true` — was rejected because it duplicates state GitHub already owns and **drifts** the moment a queue is toggled without editing every consumer's config (the same config-drift bug class this whole thread fixed).

## What

- New `base_branch_has_merge_queue(repo, branch)` reads `GET /repos/{repo}/rules/branches/{branch}` and reports whether a `merge_queue` rule is in force — the same authority the queue enforces, so it cannot disagree with reality.
- `auto_merge_pr` picks the method up front: **queue → `--auto` (no method)**; **no queue → `--auto --squash`** (+ clean-status direct-merge fallback).
- The `None` (probe-undeterminable) branch keeps the prior stderr 'merge queue' retry as a safety net, so a token lacking ruleset-read scope still degrades gracefully — no hard dependency on the new API call.

## Validation

Probe verified against ground truth: TokenSheriff (queue) → `true`, cui-java-tools / cuioss-organization (no queue) → `false`. Full `test/workflow` suite passes (53 tests incl. new probe + probe-branch coverage); ruff clean.