### PR TITLE
release: prepare 0.11.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.11.0
+  current-version: 0.11.1
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump `current-version` to 0.11.1 for release.

Ships the deterministic merge-queue probe (#186): `auto_merge_pr` reads the target branch's live ruleset to choose the merge method instead of guessing, replacing the stderr-adaptive path (kept as a fallback). Dispatch the Release workflow after merge to tag `v0.11.1`.