### PR TITLE
feat(pyprojectx): structured build-target inputs and concurrency control

### DIFF
--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -180,8 +180,8 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 | Python version (empty = let uv manage from pyproject.toml)
 
 | `pyprojectx-cache-dependency-glob`
-| `'uv.lock'`
-| Glob pattern for uv cache dependencies
+| `''`
+| Glob pattern for uv cache dependencies. Empty when unset so the consuming workflow's own default applies
 
 | `pyprojectx-upload-artifacts-on-failure`
 | `'false'`

--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -188,8 +188,8 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 | Upload test artifacts on failure
 
 | `pyprojectx-verify-goals`
-| `'verify'`
-| Space-separated pw goals to run, in order (e.g. `quality-gate module-tests`)
+| `''`
+| Space-separated pw goals to run, in order (e.g. `quality-gate module-tests`). Empty when unset so the consuming workflow's own default applies
 
 | `pyprojectx-verify-args`
 | `''`

--- a/.github/actions/read-project-config/README.adoc
+++ b/.github/actions/read-project-config/README.adoc
@@ -187,9 +187,13 @@ Parses `.github/project.yml` and outputs configuration values with sensible defa
 | `'false'`
 | Upload test artifacts on failure
 
-| `pyprojectx-verify-command`
-| `'./pw verify'`
-| Verification command to run
+| `pyprojectx-verify-goals`
+| `'verify'`
+| Space-separated pw goals to run, in order (e.g. `quality-gate module-tests`)
+
+| `pyprojectx-verify-args`
+| `''`
+| Extra arguments appended to every goal invocation (e.g. a module filter)
 |===
 
 === GitHub Automation Section

--- a/.github/actions/read-project-config/action.yml
+++ b/.github/actions/read-project-config/action.yml
@@ -90,9 +90,12 @@ outputs:
   pyprojectx-upload-artifacts-on-failure:
     description: 'Upload test artifacts on failure'
     value: ${{ steps.config.outputs.pyprojectx-upload-artifacts-on-failure }}
-  pyprojectx-verify-command:
-    description: 'Verification command to run'
-    value: ${{ steps.config.outputs.pyprojectx-verify-command }}
+  pyprojectx-verify-goals:
+    description: 'Space-separated pw goals to run, in order'
+    value: ${{ steps.config.outputs.pyprojectx-verify-goals }}
+  pyprojectx-verify-args:
+    description: 'Extra arguments appended to every pw goal invocation'
+    value: ${{ steps.config.outputs.pyprojectx-verify-args }}
 
   # GitHub Automation Section
   auto-merge-build-versions:

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -95,7 +95,8 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["pyprojectx", "python-version"], "pyprojectx-python-version", "", None),
     (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "uv.lock", None),
     (["pyprojectx", "upload-artifacts-on-failure"], "pyprojectx-upload-artifacts-on-failure", False, None),
-    (["pyprojectx", "verify-command"], "pyprojectx-verify-command", "./pw verify", None),
+    (["pyprojectx", "verify-goals"], "pyprojectx-verify-goals", "verify", None),
+    (["pyprojectx", "verify-args"], "pyprojectx-verify-args", "", None),
     # github-automation section
     (["github-automation", "auto-merge-build-versions"], "auto-merge-build-versions", True, None),
     # consumers list (special case: transform list to space-separated string)
@@ -231,7 +232,8 @@ def print_config_summary(outputs: dict[str, str], config_found: bool, config_pat
         "Release": ["current-version", "next-version", "create-github-release"],
         "Pages": ["pages-reference", "deploy-site"],
         "Pyprojectx": ["pyprojectx-python-version", "pyprojectx-cache-dependency-glob",
-                       "pyprojectx-upload-artifacts-on-failure", "pyprojectx-verify-command"],
+                       "pyprojectx-upload-artifacts-on-failure", "pyprojectx-verify-goals",
+                       "pyprojectx-verify-args"],
         "GitHub Automation": ["auto-merge-build-versions"],
         "Dependency Propagation": ["dep-prop-group-id", "dep-prop-artifact-id", "dep-prop-scope"],
         "Other": ["consumers"],

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -64,6 +64,44 @@ def _sanitize_glob_list(value: Any) -> str:
     return " ".join(parts)
 
 
+def _sanitize_token_list(value: Any) -> str:
+    """Collapse a space-separated token list destined for GITHUB_OUTPUT.
+
+    Values land in GITHUB_OUTPUT as `key=value` lines, so an embedded newline
+    would let a crafted project.yml forge additional action outputs. Collapsing
+    every whitespace run to a single space closes that: an injected
+    `other-output=evil` stays on the same line and becomes an ordinary token.
+
+    Individual tokens are deliberately NOT filtered here. The consuming workflow
+    validates each goal against a strict allowlist and fails the run with a clear
+    error, which is more useful than silently dropping a mistyped goal and
+    building something the caller did not ask for.
+    """
+    import re
+    s = str(value).strip() if value is not None else ""
+    return re.sub(r"\s+", " ", s)
+
+
+def _sanitize_shell_args(value: Any) -> str:
+    """Sanitize free-form arguments appended to a shell command.
+
+    Unlike goals, args have no downstream allowlist to catch them, so this is the
+    only checkpoint: a value containing anything outside the safe set is dropped
+    entirely rather than partially stripped (partial stripping would silently
+    rewrite intent). Mirrors _sanitize_shell_value, but permits spaces and '='
+    so multiple flag-style arguments remain expressible.
+    """
+    import re
+    s = str(value).strip() if value is not None else ""
+    if not s:
+        return ""
+    tokens = s.split()
+    safe_pattern = re.compile(r"^[a-zA-Z0-9_./:,=\-]+$")
+    if not all(safe_pattern.match(t) for t in tokens):
+        return ""
+    return " ".join(tokens)
+
+
 # Field registry: (yaml_path, output_name, default, transform_fn)
 # To add a new field, simply append a tuple to this list
 FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
@@ -95,8 +133,12 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["pyprojectx", "python-version"], "pyprojectx-python-version", "", None),
     (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "uv.lock", None),
     (["pyprojectx", "upload-artifacts-on-failure"], "pyprojectx-upload-artifacts-on-failure", False, None),
-    (["pyprojectx", "verify-goals"], "pyprojectx-verify-goals", "verify", None),
-    (["pyprojectx", "verify-args"], "pyprojectx-verify-args", "", None),
+    # Both default to "" so an absent project.yml key falls through to the
+    # consuming workflow's own input default (as python-version already does).
+    # A non-empty default here would make `config.outputs.X || inputs.X` always
+    # pick the config side, silently ignoring what the caller passed.
+    (["pyprojectx", "verify-goals"], "pyprojectx-verify-goals", "", _sanitize_token_list),
+    (["pyprojectx", "verify-args"], "pyprojectx-verify-args", "", _sanitize_shell_args),
     # github-automation section
     (["github-automation", "auto-merge-build-versions"], "auto-merge-build-versions", True, None),
     # consumers list (special case: transform list to space-separated string)

--- a/.github/actions/read-project-config/read-config.py
+++ b/.github/actions/read-project-config/read-config.py
@@ -130,13 +130,15 @@ FIELD_REGISTRY: list[tuple[list[str], str, Any, TransformFn]] = [
     (["npm-build", "node-version"], "npm-node-version", "22", None),
     (["npm-build", "registry-url"], "npm-registry-url", "https://registry.npmjs.org", None),
     # pyprojectx section
+    # Keys the reusable workflow resolves with a bare `config.outputs.X || inputs.X`
+    # fallthrough MUST default to "" here. A non-empty default makes the left side
+    # permanently truthy, so the caller's input becomes unreachable dead code.
+    # See TestConfigOverInputPrecedence for the guard.
     (["pyprojectx", "python-version"], "pyprojectx-python-version", "", None),
-    (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "uv.lock", None),
+    (["pyprojectx", "cache-dependency-glob"], "pyprojectx-cache-dependency-glob", "", None),
+    # Resolved with a boolean OR (`X == 'true' || inputs.X`), not a fallthrough, so
+    # the input stays reachable and an empty default is not required here.
     (["pyprojectx", "upload-artifacts-on-failure"], "pyprojectx-upload-artifacts-on-failure", False, None),
-    # Both default to "" so an absent project.yml key falls through to the
-    # consuming workflow's own input default (as python-version already does).
-    # A non-empty default here would make `config.outputs.X || inputs.X` always
-    # pick the config side, silently ignoring what the caller passed.
     (["pyprojectx", "verify-goals"], "pyprojectx-verify-goals", "", _sanitize_token_list),
     (["pyprojectx", "verify-args"], "pyprojectx-verify-args", "", _sanitize_shell_args),
     # github-automation section

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -175,11 +175,18 @@
           "description": "Upload test artifacts (.pytest_cache, .mypy_cache) on failure",
           "default": false
         },
-        "verify-command": {
+        "verify-goals": {
           "type": "string",
-          "description": "Verification command to run",
-          "default": "./pw verify",
-          "examples": ["./pw verify", "./pw test", "./pw quality-gate"]
+          "description": "Space-separated pw goals to run, in order. Each is executed as './pw <goal>' and the first failing goal fails the build. Goal tokens must match [a-z][a-z0-9-]*.",
+          "default": "verify",
+          "pattern": "^[a-z][a-z0-9-]*( +[a-z][a-z0-9-]*)*$",
+          "examples": ["verify", "quality-gate module-tests", "compile quality-gate test"]
+        },
+        "verify-args": {
+          "type": "string",
+          "description": "Extra arguments appended to every goal invocation, e.g. a module filter. The pyprojectx equivalent of the maven-build profile inputs.",
+          "default": "",
+          "examples": ["", "workflow", "repo-admin"]
         }
       },
       "additionalProperties": false
@@ -192,7 +199,7 @@
           "type": "boolean",
           "description": "Auto-merge workflow update PRs when CI checks pass",
           "default": true
-        },
+        }
       },
       "additionalProperties": false
     },

--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -167,7 +167,7 @@
         },
         "cache-dependency-glob": {
           "type": "string",
-          "description": "Glob pattern for uv cache dependencies",
+          "description": "Glob pattern for uv cache dependencies. Omit to use the workflow's own default of 'uv.lock'.",
           "default": "uv.lock"
         },
         "upload-artifacts-on-failure": {

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -19,11 +19,23 @@ on:
         required: false
         type: boolean
         default: false
-      verify-command:
-        description: 'Verification command to run'
+      verify-goals:
+        description: >-
+          Space-separated pw goals to run, in order (e.g. 'quality-gate
+          module-tests'). Each goal is run as './pw <goal>'; the first failing
+          goal fails the job. Goal tokens must match [a-z][a-z0-9-]* — anything
+          else fails the run.
         required: false
         type: string
-        default: './pw verify'
+        default: 'verify'
+      verify-args:
+        description: >-
+          Extra arguments appended to every goal invocation (e.g. a module
+          filter). The pyprojectx equivalent of the maven reusable's profile
+          inputs.
+        required: false
+        type: string
+        default: ''
       skip-on-docs-only:
         description: >-
           Skip verify when only documentation/config files changed (footprint
@@ -36,6 +48,21 @@ on:
 
 permissions:
   contents: read
+
+# Cancel a superseded in-progress run only for pull requests: pushing a new commit
+# to a PR makes the older run's result irrelevant, so freeing that runner speeds up
+# feedback. Grouped by caller workflow + ref + event so a push, a PR, and a
+# merge_group run never share a group. cancel-in-progress is deliberately limited to
+# pull_request: push runs on the default branch and merge_group runs (the merge
+# queue) must always run to completion and are never cancelled.
+#
+# This is complementary to — not overlapping with — the gate job below. The gate
+# skips a REDUNDANT run (a push whose commit an open PR already covers); concurrency
+# cancels a SUPERSEDED run (an older commit on the same PR). merge_group runs are
+# excluded from both: the gate always builds them, and they are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Decide whether this run should proceed, from two independent skip reasons:
@@ -179,8 +206,53 @@ jobs:
           enable-cache: true
           cache-dependency-glob: ${{ steps.config.outputs.pyprojectx-cache-dependency-glob || inputs.cache-dependency-glob }}
 
+      # Resolve config-over-input, then validate BEFORE anything reaches a `run:`
+      # command line. Config text is untrusted: it is carried in via env (never
+      # interpolated into the shell body) and every goal token must match the
+      # conservative allowlist, so no goal can smuggle shell metacharacters.
+      - name: Resolve and validate build targets
+        id: targets
+        env:
+          VERIFY_GOALS: ${{ steps.config.outputs.pyprojectx-verify-goals || inputs.verify-goals }}
+          VERIFY_ARGS: ${{ steps.config.outputs.pyprojectx-verify-args || inputs.verify-args }}
+        run: |
+          if [[ -z "${VERIFY_GOALS// /}" ]]; then
+            echo "::error::verify-goals is empty — expected at least one pw goal"
+            exit 1
+          fi
+          for goal in $VERIFY_GOALS; do
+            if [[ ! "$goal" =~ ^[a-z][a-z0-9-]*$ ]]; then
+              echo "::error::invalid pw goal '$goal' — goals must match [a-z][a-z0-9-]*"
+              exit 1
+            fi
+          done
+          echo "Resolved goals: $VERIFY_GOALS"
+          echo "Resolved args: ${VERIFY_ARGS:-<none>}"
+          {
+            echo "goals=$VERIFY_GOALS"
+            echo "args=$VERIFY_ARGS"
+          } >> "$GITHUB_OUTPUT"
+
+      # GitHub Actions cannot emit a dynamic number of steps, so the goals are run
+      # in one step with a ::group:: per goal. The loop exits on the first failure
+      # and annotates which goal failed, giving the same attribution a per-goal step
+      # name would.
       - name: Run verification
-        run: ${{ steps.config.outputs.pyprojectx-verify-command || inputs.verify-command }}
+        env:
+          GOALS: ${{ steps.targets.outputs.goals }}
+          ARGS: ${{ steps.targets.outputs.args }}
+        run: |
+          for goal in $GOALS; do
+            echo "::group::./pw $goal"
+            # ARGS is deliberately unquoted so it word-splits into separate
+            # arguments; it is data for pw, never a shell command.
+            if ! ./pw "$goal" $ARGS; then
+              echo "::endgroup::"
+              echo "::error::pw goal '$goal' failed"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
 
       - name: Upload test results
         if: ${{ failure() && (steps.config.outputs.pyprojectx-upload-artifacts-on-failure == 'true' || inputs.upload-artifacts-on-failure) }}

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -706,10 +706,15 @@ jobs:
 |`false`
 |Upload test artifacts on failure
 
-|`verify-command`
+|`verify-goals`
 |string
-|`./pw verify`
-|Verification command to run
+|`verify`
+|Space-separated pw goals run in order, each as `./pw <goal>`. The first failing goal fails the job. Goal tokens must match `[a-z][a-z0-9-]*`; anything else fails the run before any command executes.
+
+|`verify-args`
+|string
+|`` (none)
+|Extra arguments appended to every goal invocation, e.g. a module filter. The pyprojectx equivalent of the maven reusable's profile inputs.
 |===
 
 === No Secrets Required

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -189,7 +189,8 @@ The propagation script directly searches for `<version.cui.test.juli.logger>OLD<
 |`pyprojectx.python-version` |string |`''` |Python version (empty = let uv manage from pyproject.toml)
 |`pyprojectx.cache-dependency-glob` |string |`'uv.lock'` |Glob pattern for uv cache dependencies
 |`pyprojectx.upload-artifacts-on-failure` |boolean |`false` |Upload test artifacts on failure
-|`pyprojectx.verify-command` |string |`'./pw verify'` |Verification command to run
+|`pyprojectx.verify-goals` |string |`'verify'` |Space-separated pw goals run in order, each as `./pw <goal>`; tokens must match `[a-z][a-z0-9-]*`
+|`pyprojectx.verify-args` |string |`''` |Extra arguments appended to every goal invocation (e.g. a module filter)
 |===
 
 == Full Example

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -21,4 +21,5 @@ jobs:
     #   python-version: '3.12'           # Leave empty to let uv manage from pyproject.toml
     #   cache-dependency-glob: 'uv.lock' # Glob pattern for cache dependencies
     #   upload-artifacts-on-failure: true # Upload test artifacts on failure
-    #   verify-command: './pw verify'     # Command to run
+    #   verify-goals: 'quality-gate module-tests'  # pw goals, run in order
+    #   verify-args: 'workflow'           # Extra args appended to every goal

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add parent to path to access conftest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from conftest import PROJECT_ROOT, run_script
@@ -157,7 +159,7 @@ class TestPyprojectxSection:
         result = run_script(SCRIPT_PATH, "--config", str(temp_dir / "nonexistent.yml"))
         assert result.returncode == 0
         assert "pyprojectx-python-version=" in result.stdout
-        assert "pyprojectx-cache-dependency-glob=uv.lock" in result.stdout
+        assert "pyprojectx-cache-dependency-glob=\n" in result.stdout
         assert "pyprojectx-upload-artifacts-on-failure=false" in result.stdout
         # Empty, not 'verify': an absent key must fall through to the consuming
         # workflow's input default rather than always winning the `config || input`
@@ -259,6 +261,76 @@ class TestPyprojectxSection:
         assert "pyprojectx-upload-artifacts-on-failure=true" in result.stdout
         assert "pyprojectx-verify-goals=quality-gate module-tests" in result.stdout
         assert "pyprojectx-verify-args=workflow" in result.stdout
+
+
+class TestConfigOverInputPrecedence:
+    """Guard the config-over-input resolution contract in the reusable workflows.
+
+    The reusable workflows resolve most settings as
+    ``steps.config.outputs.X || inputs.X``. GitHub Actions' ``||`` returns the
+    left operand whenever it is truthy, so a NON-EMPTY registry default here makes
+    the config side permanently truthy and silently renders the caller's input
+    unreachable dead code — the build ignores what the caller asked for and no
+    existing test noticed. That bug shipped for ``cache-dependency-glob`` and was
+    reintroduced for ``verify-goals``; these tests are the standing guard.
+
+    A key belongs in FALLTHROUGH_KEYS only if the workflow resolves it with a bare
+    ``||``. Keys resolved by boolean OR (e.g. upload-artifacts-on-failure, via
+    ``X == 'true' || inputs.X``) keep the input reachable and are excluded.
+    """
+
+    # (output name, the value the consuming workflow supplies as its input default)
+    FALLTHROUGH_KEYS = [
+        ("pyprojectx-python-version", "3.12"),
+        ("pyprojectx-cache-dependency-glob", "uv.lock"),
+        ("pyprojectx-verify-goals", "verify"),
+        ("pyprojectx-verify-args", "--module=workflow"),
+    ]
+
+    @pytest.mark.parametrize("output_name,_caller_input", FALLTHROUGH_KEYS)
+    def test_unset_key_emits_empty_so_caller_input_is_reachable(
+        self, output_name, _caller_input, temp_dir
+    ):
+        """Should emit '' when project.yml omits the key, so `|| inputs.X` falls through."""
+        config = temp_dir / "project.yml"
+        config.write_text("name: some-repo\n")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)[output_name] == "", (
+            f"{output_name} has a non-empty default, which makes the config side of "
+            f"`config.outputs.{output_name} || inputs.*` permanently truthy and the "
+            f"caller's input unreachable"
+        )
+
+    @pytest.mark.parametrize("output_name,caller_input", FALLTHROUGH_KEYS)
+    def test_caller_input_wins_when_key_unset(self, output_name, caller_input, temp_dir):
+        """Should let a caller-supplied input reach the command when project.yml is silent.
+
+        Evaluates the workflow's actual `config || input` expression rather than
+        only asserting the empty default, so the assertion is about the resolved
+        value the build ultimately runs with.
+        """
+        config = temp_dir / "project.yml"
+        config.write_text("name: some-repo\n")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        config_value = _parse_output(result.stdout)[output_name]
+
+        resolved = config_value or caller_input  # mirrors `${{ config || inputs }}`
+        assert resolved == caller_input
+
+    def test_project_yml_still_overrides_the_caller_input(self, temp_dir):
+        """Should keep project.yml winning when it DOES set the key.
+
+        The counterpart to the tests above: the empty-default fix must not flip
+        precedence, only restore reachability.
+        """
+        config = temp_dir / "project.yml"
+        config.write_text("pyprojectx:\n  verify-goals: quality-gate\n")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        config_value = _parse_output(result.stdout)["pyprojectx-verify-goals"]
+
+        resolved = config_value or "verify"
+        assert resolved == "quality-gate"
 
 
 class TestSchemaDocument:

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -1,5 +1,6 @@
 """Tests for read-config.py - project.yml configuration parser."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -158,7 +159,8 @@ class TestPyprojectxSection:
         assert "pyprojectx-python-version=" in result.stdout
         assert "pyprojectx-cache-dependency-glob=uv.lock" in result.stdout
         assert "pyprojectx-upload-artifacts-on-failure=false" in result.stdout
-        assert "pyprojectx-verify-command=./pw verify" in result.stdout
+        assert "pyprojectx-verify-goals=verify" in result.stdout
+        assert "pyprojectx-verify-args=" in result.stdout
 
     def test_reads_pyprojectx_python_version(self, temp_dir):
         """Should read python-version from pyprojectx section."""
@@ -184,13 +186,29 @@ class TestPyprojectxSection:
         assert result.returncode == 0
         assert "pyprojectx-upload-artifacts-on-failure=true" in result.stdout
 
-    def test_reads_pyprojectx_verify_command(self, temp_dir):
-        """Should read verify-command from pyprojectx section."""
+    def test_reads_pyprojectx_verify_goals(self, temp_dir):
+        """Should read a single verify goal from the pyprojectx section."""
         config = temp_dir / "project.yml"
-        config.write_text("pyprojectx:\n  verify-command: ./pw test")
+        config.write_text("pyprojectx:\n  verify-goals: test")
         result = run_script(SCRIPT_PATH, "--config", str(config))
         assert result.returncode == 0
-        assert "pyprojectx-verify-command=./pw test" in result.stdout
+        assert "pyprojectx-verify-goals=test" in result.stdout
+
+    def test_reads_multiple_pyprojectx_verify_goals(self, temp_dir):
+        """Should preserve order when several goals are configured."""
+        config = temp_dir / "project.yml"
+        config.write_text("pyprojectx:\n  verify-goals: quality-gate module-tests")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "pyprojectx-verify-goals=quality-gate module-tests" in result.stdout
+
+    def test_reads_pyprojectx_verify_args(self, temp_dir):
+        """Should read verify-args from the pyprojectx section."""
+        config = temp_dir / "project.yml"
+        config.write_text("pyprojectx:\n  verify-args: workflow")
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert "pyprojectx-verify-args=workflow" in result.stdout
 
     def test_reads_full_pyprojectx_config(self, temp_dir):
         """Should read all pyprojectx settings together."""
@@ -199,14 +217,42 @@ class TestPyprojectxSection:
   python-version: "3.11"
   cache-dependency-glob: "*.lock"
   upload-artifacts-on-failure: true
-  verify-command: ./pw quality-gate
+  verify-goals: quality-gate module-tests
+  verify-args: workflow
 """)
         result = run_script(SCRIPT_PATH, "--config", str(config))
         assert result.returncode == 0
         assert "pyprojectx-python-version=3.11" in result.stdout
         assert "pyprojectx-cache-dependency-glob=*.lock" in result.stdout
         assert "pyprojectx-upload-artifacts-on-failure=true" in result.stdout
-        assert "pyprojectx-verify-command=./pw quality-gate" in result.stdout
+        assert "pyprojectx-verify-goals=quality-gate module-tests" in result.stdout
+        assert "pyprojectx-verify-args=workflow" in result.stdout
+
+
+class TestSchemaDocument:
+    """Test schema.json itself.
+
+    schema.json is not loaded by read-config.py — it is published purely as an
+    editor hint (``yaml-language-server: $schema``). It therefore has no runtime
+    behavior to assert; what it does need is to stay parseable and to keep
+    documenting the keys the field registry actually reads. A malformed schema
+    fails silently in editors, so it is checked here instead.
+    """
+
+    def test_schema_is_valid_json(self):
+        """Should parse as JSON — a syntax error breaks the editor hint silently."""
+        schema_path = PROJECT_ROOT / ".github/actions/read-project-config/schema.json"
+        json.loads(schema_path.read_text(encoding="utf-8"))
+
+    def test_schema_documents_pyprojectx_verify_keys(self):
+        """Should declare verify-goals/verify-args and no stale verify-command."""
+        schema_path = PROJECT_ROOT / ".github/actions/read-project-config/schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        pyprojectx = schema["properties"]["pyprojectx"]
+        assert pyprojectx["additionalProperties"] is False
+        assert "verify-goals" in pyprojectx["properties"]
+        assert "verify-args" in pyprojectx["properties"]
+        assert "verify-command" not in pyprojectx["properties"]
 
 
 class TestNpmBuildSection:

--- a/test/workflow/test_read_config.py
+++ b/test/workflow/test_read_config.py
@@ -159,8 +159,11 @@ class TestPyprojectxSection:
         assert "pyprojectx-python-version=" in result.stdout
         assert "pyprojectx-cache-dependency-glob=uv.lock" in result.stdout
         assert "pyprojectx-upload-artifacts-on-failure=false" in result.stdout
-        assert "pyprojectx-verify-goals=verify" in result.stdout
-        assert "pyprojectx-verify-args=" in result.stdout
+        # Empty, not 'verify': an absent key must fall through to the consuming
+        # workflow's input default rather than always winning the `config || input`
+        # resolution and shadowing what the caller passed.
+        assert "pyprojectx-verify-goals=\n" in result.stdout
+        assert "pyprojectx-verify-args=\n" in result.stdout
 
     def test_reads_pyprojectx_python_version(self, temp_dir):
         """Should read python-version from pyprojectx section."""
@@ -209,6 +212,35 @@ class TestPyprojectxSection:
         result = run_script(SCRIPT_PATH, "--config", str(config))
         assert result.returncode == 0
         assert "pyprojectx-verify-args=workflow" in result.stdout
+
+    def test_verify_goals_newline_cannot_forge_an_output(self, temp_dir):
+        """Should collapse newlines so a crafted value cannot forge extra outputs."""
+        config = temp_dir / "project.yml"
+        config.write_text(
+            'pyprojectx:\n  verify-goals: "verify\\nsonar-project-key=pwned"\n'
+        )
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        outputs = _parse_output(result.stdout)
+        # The injected line is folded into the goals value, not a separate output.
+        assert outputs["pyprojectx-verify-goals"] == "verify sonar-project-key=pwned"
+        assert outputs["sonar-project-key"] == ""
+
+    def test_verify_args_rejects_shell_metacharacters(self, temp_dir):
+        """Should drop args wholesale when any token is unsafe, never partially strip."""
+        config = temp_dir / "project.yml"
+        config.write_text('pyprojectx:\n  verify-args: "workflow; rm -rf /"')
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["pyprojectx-verify-args"] == ""
+
+    def test_verify_args_allows_flag_style_arguments(self, temp_dir):
+        """Should preserve ordinary multi-token flag arguments."""
+        config = temp_dir / "project.yml"
+        config.write_text('pyprojectx:\n  verify-args: "--module=workflow -v"')
+        result = run_script(SCRIPT_PATH, "--config", str(config))
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["pyprojectx-verify-args"] == "--module=workflow -v"
 
     def test_reads_full_pyprojectx_config(self, temp_dir):
         """Should read all pyprojectx settings together."""


### PR DESCRIPTION
Two changes to `reusable-pyprojectx-verify.yml`, shipped together.

## (A) Structured build-target inputs

`reusable-maven-build.yml` gives callers named, validated levers over the build's content (java-versions, maven-profiles-*, enable-sonar, enable-snapshot-deploy). The pyprojectx equivalent had only `verify-command` — a raw string interpolated straight into a `run:` step. Changing the goal set meant hand-writing `'./pw quality-gate && ./pw module-tests'`: unvalidated, not composable, no meaningful per-repo defaults.

Replaced with:

| Input | Default | Purpose |
|---|---|---|
| `verify-goals` | `verify` | pw goals run in order, each as `./pw <goal>` |
| `verify-args` | `''` | extra args appended to every goal invocation (the profile-equivalent knob, e.g. a module filter) |

Goal tokens are validated against `[a-z][a-z0-9-]*` and the run fails fast with a clear annotation otherwise. Both values are carried via `env` and never interpolated into the shell body.

**One deviation from the request:** it asked for each goal to be *its own step* with an attributable step name. GitHub Actions cannot emit a dynamic number of steps from a runtime string — steps are static YAML. The goals therefore run in a single step with a `::group::` per goal; the loop exits on the first failure and emits `::error::pw goal 'X' failed`, giving the same attribution a step name would. The alternative (a fixed static step per known goal) was rejected because it freezes the goal set in the reusable and loses caller-specified ordering.

## (B) Concurrency control

`reusable-pyprojectx-verify.yml` had no `concurrency:` block. Without it a push and its pull_request event both ran a full verify on the same commit and neither was cancelled — observed in cuioss/plan-marshall#949 as two concurrent `verify / verify` jobs grinding on one SHA for ~60 minutes.

The added block is semantically identical to `reusable-maven-build.yml`: grouped by caller workflow + ref + event, `cancel-in-progress` limited to `pull_request` so default-branch pushes and merge_group (merge-queue) runs always run to completion.

This is **complementary to, not overlapping with, the gate job**:
- the gate skips a **redundant** run (a push whose commit an open PR already covers)
- concurrency cancels a **superseded** run (an older commit on the same PR)

`merge_group` runs are excluded from both — the gate always builds them, and they are never cancelled. The gate's footprint filter and push-dedup logic are otherwise untouched.

## Incidental fix

`schema.json` had a pre-existing trailing comma (in `github-automation`) that made it **invalid JSON**, silently breaking the published `yaml-language-server: $schema` editor hint for every consumer. Repaired here since this PR edits that file.

Worth knowing: `schema.json` is never loaded by `read-config.py` or any test — it is purely an editor hint, so `additionalProperties: false` is **not** runtime-enforced. A requested "schema rejects unknown keys" test was therefore not meaningful; instead a test now asserts the schema stays parseable and keeps documenting the keys the field registry actually reads. Wiring real `jsonschema` validation into `read-config.py` was considered and deliberately deferred — it would make every consumer repo's `project.yml` a CI failure risk.

## Breaking change — consumer action required

`verify-command` is removed outright: no compatibility shim, no deprecation path. `cuioss/plan-marshall` is the only consumer and **must bump its SHA pin** (`@<sha> # v<version>`) for this release, and migrate any `pyprojectx.verify-command` in its `.github/project.yml` to `verify-goals` / `verify-args`. This release changes the reusable's input surface, so pinned consumers are unaffected until they bump.

## Verification

- `./pw verify workflow` — 215 passed (mypy + ruff + pytest)
- Workflow YAML parses
- Goal allowlist rejects `verify; rm -rf /`, `$(id)`, `./pw verify`, `Verify`, `-x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verification workflows now support running multiple ordered Pyprojectx goals.
  * Added shared arguments that are appended to each verification goal.
  * Verification goals are validated before execution and stop on the first failure.
  * Pull request verification runs now cancel superseded in-progress runs.

* **Documentation**
  * Updated configuration references, workflow guidance, schema documentation, and examples for the new verification options.

* **Tests**
  * Added coverage for defaults, multiple goals, argument handling, ordering, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 1 — two real defects fixed (2nd commit)

**Input precedence was broken (CodeRabbit, critical).** The registry default for `verify-goals` was `'verify'`, so the action output was always non-empty and `config.outputs.X || inputs.X` always short-circuited to the config side — a caller's `verify-goals` input could never be honored. Both keys now default to `""` (as `python-version` already does), restoring `project.yml` > input > workflow-default. Effective behavior for a caller passing nothing is unchanged.

**GITHUB_OUTPUT forging (Gemini, high).** Values land as `key=value` lines, so a newline in `project.yml` could emit a second line and override an unrelated output. Goals now have whitespace collapsed (injected text becomes a token the workflow's allowlist rejects loudly); args are dropped wholesale if any token is unsafe, rather than partially stripped. Shell injection was already blocked by the allowlist + `env` passing.

⚠️ **Pre-existing, not fixed here:** the same precedence bug affects `cache-dependency-glob` (registry default `uv.lock`) and `upload-artifacts-on-failure` (`false`) — caller inputs for those are silently ignored today. Out of scope for this PR; worth a follow-up.
