### PR TITLE
release: prepare 0.12.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.11.1
+  current-version: 0.12.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.12.0 for release.

## Contents

- #188 — pyprojectx reusable: structured `verify-goals` / `verify-args` inputs replacing `verify-command`, plus the `concurrency:` block; input-precedence and GITHUB_OUTPUT-sanitization fixes for the pyprojectx config keys
- #190 — CI self-test exercising composite actions via local path ref

## ⚠️ Breaking

`verify-command` is removed from `reusable-pyprojectx-verify.yml` and from the `pyprojectx` project.yml schema, with no compatibility shim. `cuioss/plan-marshall` is the only pyprojectx consumer; after its workflow pin is bumped it must use `verify-goals` / `verify-args`. Consumers passing no inputs are unaffected — the default still resolves to `./pw verify`, verified end-to-end in a runner.

Minor bump rather than patch: pre-1.0, breaking changes land in minor.