### PR TITLE
fix(release): merge directly when auto-merge is refused for unstable status

### DIFF
--- a/test/workflow/test_consumer_update_utils.py
+++ b/test/workflow/test_consumer_update_utils.py
@@ -301,6 +301,39 @@ class TestAutoMergePr:
         assert "--auto" not in third_call_args
 
     @patch("consumer_update_utils.run_gh")
+    def test_falls_back_to_direct_merge_on_unstable_status(self, mock_gh):
+        """No queue + unstable status: fall back to a direct squash merge.
+
+        UNSTABLE means the required checks are green but a NON-required check is
+        pending or failing (e.g. an advisory CLA check), so auto-merge has no gate
+        left to wait on and GitHub refuses to enable it. Before this was handled,
+        the PR fell through to a warning and was stranded with nothing to retry it
+        — which is what happened to playwright-test-artifacts#115 on v0.12.0.
+        """
+        mock_gh.side_effect = [
+            _probe(False),
+            MagicMock(returncode=1, stderr="GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)"),
+            MagicMock(returncode=0),  # direct merge succeeds
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is True
+        assert mock_gh.call_count == 3
+        third_call_args = mock_gh.call_args_list[2][0][0]
+        assert "--auto" not in third_call_args
+        assert "--squash" in third_call_args
+
+    @patch("consumer_update_utils.run_gh")
+    def test_unstable_status_reports_failure_when_direct_merge_fails(self, mock_gh):
+        """Should not claim success when the unstable fallback merge itself fails."""
+        mock_gh.side_effect = [
+            _probe(False),
+            MagicMock(returncode=1, stderr="GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)"),
+            MagicMock(returncode=1, stderr="merge conflict"),  # direct merge fails
+        ]
+        result = utils.auto_merge_pr("cuioss/repo", "https://github.com/cuioss/repo/pull/1")
+        assert result is False
+
+    @patch("consumer_update_utils.run_gh")
     def test_probe_undeterminable_retries_on_merge_queue_error(self, mock_gh):
         """Probe fails (None); the no-queue attempt hits a queue error → retry --auto."""
         mock_gh.side_effect = [

--- a/workflow-scripts/consumer_update_utils.py
+++ b/workflow-scripts/consumer_update_utils.py
@@ -139,10 +139,11 @@ def auto_merge_pr(full_repo: str, pr_url: str, base_branch: str = "main") -> boo
       ``--auto`` and no method; the queue re-tests against the latest base and
       merges with its configured method.
     * **No merge queue** — ``gh`` requires an explicit method, so pass
-      ``--squash``. When every required check is already green (e.g.
-      workflow-only changes where build checks are skipped), ``--auto`` is
-      rejected with a "clean status" error and we fall back to an immediate
-      squash merge.
+      ``--squash``. When there is nothing left for auto-merge to wait on,
+      ``--auto`` is rejected and we fall back to an immediate squash merge. That
+      covers both "clean status" (every required check green, e.g. workflow-only
+      changes where build checks are skipped) and "unstable status" (required
+      checks green, a non-required check still pending or failing).
     * **Probe undeterminable** (``None``) — try the no-queue form and adapt on
       the stderr: a "merge queue" rejection means the repo did have a queue
       after all, so retry ``--auto`` without a method flag. This preserves the
@@ -190,11 +191,20 @@ def auto_merge_pr(full_repo: str, pr_url: str, base_branch: str = "main") -> boo
         print(f"::warning::Failed to enqueue on merge-queue repo: {queued.stderr}")
         return False
 
-    # No queue + all required checks already satisfied (e.g. workflow-only
-    # changes where build checks are skipped): gh returns a "clean status"
-    # error. Fall back to an immediate merge.
-    if "clean status" in low:
-        print("PR already in clean status, merging directly...")
+    # No queue + nothing left for auto-merge to wait on. GitHub refuses to enable
+    # auto-merge in two such states, and both mean "just merge it":
+    #   clean    — every required check already satisfied (e.g. workflow-only
+    #              changes where build checks are skipped)
+    #   unstable — required checks satisfied, but a NON-required check is still
+    #              pending or failing (e.g. an advisory CLA check). The PR is
+    #              mergeable; auto-merge has no gate left to wait for.
+    # Without the unstable branch the PR falls through to the warning below and is
+    # stranded: nothing retries, so it sits open indefinitely with green required
+    # checks. That happened to playwright-test-artifacts#115 on the v0.12.0
+    # release, where an advisory license/cla check held the PR at UNSTABLE.
+    if "clean status" in low or "unstable status" in low:
+        state = "unstable" if "unstable status" in low else "clean"
+        print(f"PR already in {state} status, merging directly...")
         merge_result = run_gh(["pr", "merge", "--squash", pr_url], check=False)
         if merge_result.returncode == 0:
             print(f"PR merged directly: {pr_url}")


### PR DESCRIPTION
Fixes the one consumer PR that got stranded on the v0.12.0 release.

## What happened

`playwright-test-artifacts#115` sat open with every required check green. The release log showed:

```
Failed to enable auto-merge: GraphQL: Pull request is in unstable status (enablePullRequestAutoMerge)
```

`auto_merge_pr` already handles the sibling refusal — `"clean status"` falls back to a direct squash merge. `"unstable status"` was handled nowhere, so it fell through to the warning and returned `False`. Nothing retries, so the PR stays open indefinitely.

## Why merging is the right response

`UNSTABLE` means required checks are green but a **non-required** check is pending or failing — here, an advisory `license/cla` check that reads `pending` even on PRs that merged fine. The PR is mergeable and auto-merge has no gate left to wait on, which is exactly why GitHub refuses to enable it. Same situation as `clean`, same correct action.

Verified for the affected repo before merging it by hand: no merge queue, no required status checks, `mergeable=MERGEABLE`. A direct squash merge was correct, and is what the fallback now performs.

## Not the failure mode the release skill already knows about

This is **not** the "GitHub dropped the push event" stuck-PR case documented in `/release-next`. There the build is missing and the remedy is to trigger it. Here the builds all ran and passed — only the merge trigger was absent. Applying the documented remedy would have been the wrong fix.

## Tests

Two added to `TestAutoMergePr`:
- `test_falls_back_to_direct_merge_on_unstable_status` — asserts the fallback runs `--squash` without `--auto`
- `test_unstable_status_reports_failure_when_direct_merge_fails` — asserts it still returns `False` when the fallback merge itself fails, so a real failure is not masked as success

229 passing.

## Release

Deliberately not cutting a release for this. It only affects consumer PRs during a release, v0.12.0 already shipped cleanly with all 21 consumers merged, and a release solely for this would re-fan-out 21 PRs — using the old code path anyway. It ships with whatever goes out next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request auto-merge handling when required checks are unstable or GitHub rejects auto-merge.
  * Falls back to a direct squash merge when no merge queue is available.
  * Correctly reports failure when the fallback merge encounters an error.
* **Tests**
  * Added coverage for unstable-status fallback merges and merge conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->