### PR TITLE
docs(release): teach the skill about CLA noise and merge nudges

### DIFF
--- a/.claude/commands/release-next.md
+++ b/.claude/commands/release-next.md
@@ -57,8 +57,18 @@ Trigger a release of cuioss-organization by bumping `current-version` in `projec
    - Wait 2 minutes for workflow-reference-update PRs to be created
    - For each consumer, check for open/merged PRs from cuioss-release-bot:
      `gh pr list --repo cuioss/{consumer} --search "author:app/cuioss-release-bot" --json number,title,state -q '.[]'`
-   - If any PRs are still OPEN, check their status checks. If a required check failed with an infrastructure error (not a real build failure), re-run it: `gh run rerun {run-id} --repo cuioss/{consumer} --failed`
+   - **Ignore `license/cla` when triaging OPEN PRs — it is expected noise, not a blocker.** The cla-assistant check sits `pending` ("Contributor License Agreement is not signed yet") on *every* cuioss-release-bot PR org-wide, because a GitHub App bot never signs a CLA. It is **not a required check**, so PRs merge with it pending (confirmed: `cui-http`, `plan-marshall`, and others have merged this way). When deciding whether a PR is genuinely blocked vs. still running, filter it out:
+     ```
+     gh pr checks {pr} --repo cuioss/{consumer} | awk -F'\t' '$2!="pass" && $2!="skipping"' | grep -v 'license/cla'
+     ```
+     Treating `license/cla` as blocking wastes a full poll cycle making green PRs look stuck — do not wait on it and do not report it as a problem.
+   - If any PRs are still OPEN, check their status checks (minus `license/cla`, per above). If a required check failed with an infrastructure error (not a real build failure), re-run it: `gh run rerun {run-id} --repo cuioss/{consumer} --failed`
    - Wait and re-check until all PRs are merged (up to 5 minutes, polling every 30s)
+   - **Nudge auto-merge-refused PRs (`UNSTABLE` + auto-merge off):** A PR whose `mergeStateStatus` is `UNSTABLE` with `autoMergeRequest == null`, but whose only non-green check is `license/cla`, is the scenario #192 addressed: the release bot's auto-merge was refused for the unstable status and never re-enabled. It will **not** self-resolve. Merge it directly once its real checks are green:
+     ```
+     gh pr merge {pr} --repo cuioss/{consumer} --squash --delete-branch
+     ```
+     If the repo has a merge queue, this reports "already queued to merge" and the PR lands via the queue a few minutes later — poll `state` until `MERGED` rather than re-issuing the merge.
    - **Detect stuck PRs (missing push event):** For any PR still OPEN after polling, check if the `build` check is `SKIPPED` and no `push`-event Maven Build run exists for the branch:
      ```
      gh run list --repo cuioss/{consumer} --branch {head-branch} --json event,name,conclusion -q '.[] | select(.name == "Maven Build" and .event == "push")'
@@ -74,6 +84,8 @@ Trigger a release of cuioss-organization by bumping `current-version` in `projec
      - For each workflow file, fetch content and grep for `cuioss-organization`: `gh api repos/cuioss/{consumer}/contents/{path} --jq '.content' | base64 -d | grep "cuioss-organization"`
      - Every `uses:` reference must contain `@{tag-sha} # v{new-version}`
    - Report mismatches per repo. If a consumer still shows old SHA, its PR likely hasn't merged yet — wait and retry.
+   - **Note on the tag SHA:** since #193, the *consumer-facing* ref (what consumers pin) is the **tag** commit, which is one commit *after* the release commit. `git rev-parse v{new-version}^{commit}` returns the correct value to match against. Do not expect it to equal the `release: prepare` commit SHA — the tag deliberately lands on the later `pin internal action references` commit.
+   - **Prefer a small Python script over a shell one-liner for this fan-out.** Base64-decoding, regex-matching a SHA, skipping commented `uses:` lines, and running ~21 repos concurrently is fragile as a nested-quoted Bash pipe (it silently produced no output in one run). A `ThreadPoolExecutor` over `gh api` calls that flags any ref whose SHA ≠ the tag SHA is more reliable and easier to read.
 
 9. **Report**
    - Display summary:
@@ -101,3 +113,6 @@ Trigger a release of cuioss-organization by bumping `current-version` in `projec
 - **NEVER manually tag or create releases** — always use this workflow so `update-workflow-references.py` runs correctly
 - The release workflow is `workflow_dispatch` — it must be triggered explicitly after the version PR merges
 - Use parallel Task agents for batch-checking consumer repos to speed up verification
+- **`license/cla` is permanent noise on release-bot PRs** — it is `pending` on every cuioss-release-bot PR (a bot cannot sign a CLA), is not a required check, and never blocks merge. Never wait on it or report it as a problem. If you want it to stop being noise, allowlist `cuioss-release-bot` in cla-assistant — but that is a repo-config change, out of scope for the release itself.
+- **A consumer PR may need a manual merge nudge.** When auto-merge is refused for an `UNSTABLE` status (per #192) it does not re-enable; once real checks are green, `gh pr merge --squash` completes it (via the merge queue if the repo has one). This is expected, not a failure of the release.
+- **Since #193, the release ships two internal SHAs by design.** The tagged commit pins executed composite-action refs to the *release* commit (so the artifact is fully SHA-pinned); consumer-facing refs point at the *tag*. The release workflow's "Verify commit to be tagged is fully SHA-pinned" step (`workflow-scripts/check-internal-pinning.py`) guards this — if it ever fails, the release stops before tagging and the fix is a sequencing bug, not something to bypass.


### PR DESCRIPTION
Captures operational knowledge from the v0.13.0 release into the `release-next` command so the next run does not re-learn it the slow way.

## What this run surfaced

- **`license/cla` is permanent noise on release-bot PRs.** It sits `pending` ("CLA not signed") on *every* cuioss-release-bot PR org-wide — a GitHub App bot never signs a CLA — and it is **not a required check**. Confirmed: `cui-http #116`, `plan-marshall #953` and others merged with it pending. Treating it as blocking made three already-green PRs look stuck for a full poll cycle.
- **An `UNSTABLE` PR whose auto-merge was refused (per #192) needs a manual nudge.** `nifi-extensions #463` sat open until `gh pr merge --squash`, which landed it via the merge queue.
- **The SHA-verify fan-out is fragile as a nested-quoted shell one-liner** — it silently produced no output once this run; a small `ThreadPoolExecutor` Python script was reliable.
- **The #193 two-SHA layout** (tag commit ≠ release commit) is now recorded so the distinction is not mistaken for a mismatch.

## Changes

- Step 7: ignore `license/cla` when triaging; explicit filter command; nudge procedure for auto-merge-refused PRs
- Step 8: note the tag-vs-release-commit SHA distinction; prefer Python over a shell pipe for the fan-out
- Important Notes: three durable entries (CLA noise, merge nudge, two-SHA-by-design guard)

Docs-only; no workflow or script behavior changes.