### PR TITLE
feat(pr-agent): add opt-in third PR reviewer on Google Gemini

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -77,7 +77,9 @@ jobs:
     #                             review of that decision.
     # issue_comment branch: an explicit slash-command from a human on a pull request. A
     # deliberate /review overrides the skip label — someone is asking on purpose. Bot senders
-    # are excluded so the reviewer cannot retrigger itself off its own comment.
+    # are excluded so the reviewer cannot retrigger itself off its own comment. The commands
+    # are matched individually rather than by a bare leading "/": any other slash-prefixed
+    # comment would otherwise start a runner for a command PR-Agent does not implement.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -89,7 +91,13 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         github.event.sender.type != 'Bot' &&
-        startsWith(github.event.comment.body, '/')
+        (
+          startsWith(github.event.comment.body, '/review') ||
+          startsWith(github.event.comment.body, '/improve') ||
+          startsWith(github.event.comment.body, '/describe') ||
+          startsWith(github.event.comment.body, '/ask') ||
+          startsWith(github.event.comment.body, '/help')
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -104,6 +112,11 @@ jobs:
       # downstream review-ingestion can attribute findings to it. `repositories` MUST include
       # pr-agent-settings: without read access to it PR-Agent skips the central configuration
       # silently, with no error in the log.
+      #
+      # `owner: cuioss` is deliberately fixed, not derived from github.repository: the App
+      # installation and the pr-agent-settings repo are both organization-scoped, so this
+      # workflow is only callable from cuioss repositories. (The repository NAME is dynamic,
+      # so a renamed repo needs no change here.)
       - name: Generate Review Token
         id: review-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -1,0 +1,133 @@
+name: PR Agent Review (Reusable)
+# Third automated PR reviewer for the cuioss org, beside CodeRabbit and Sourcery.
+# Runs the open-source PR-Agent (The-PR-Agent/pr-agent) on Google Gemini.
+#
+# Tuning lives centrally in cuioss/pr-agent-settings (.pr_agent.toml) — NOT here. Model and
+# tool tuning must never be set in this workflow's `env:`, because environment variables are
+# the highest-precedence configuration source and would silently decentralize them.
+#
+# What DOES live here, by necessity: the org skip rules. PR-Agent's ignore_pr_labels /
+# ignore_pr_authors / ignore_pr_title settings are read only by its webhook servers
+# (should_process_pr_logic) and are ignored entirely in GitHub Action mode, so they are
+# enforced as the job-level `if:` guard below. See cuioss/pr-agent-settings/README.adoc.
+
+on:
+  workflow_call:
+    inputs:
+      auto-review:
+        description: 'Run /review automatically on a new pull request.'
+        required: false
+        type: boolean
+        default: true
+      auto-describe:
+        description: >-
+          Run /describe automatically. Off by default: it rewrites the pull request
+          description, which collides with generated PR bodies and the machine-readable
+          blocks our automation reads out of them.
+        required: false
+        type: boolean
+        default: false
+      auto-improve:
+        description: >-
+          Run /improve automatically. Off by default: committable suggestions are already
+          CodeRabbit's job, so enabling this duplicates findings and roughly doubles the
+          token cost per pull request.
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        description: 'Hard cap for the reviewer job.'
+        required: false
+        type: number
+        default: 15
+    secrets:
+      REVIEW_APP_ID:
+        description: 'cuioss-review-bot GitHub App ID (organization-level).'
+        required: true
+      REVIEW_APP_PRIVATE_KEY:
+        description: 'cuioss-review-bot private key (organization-level).'
+        required: true
+      GEMINI_API_KEY:
+        description: 'Google AI Studio API key, billing-enabled (organization-level).'
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+# One reviewer run per pull request; a superseded run is worth nothing and costs tokens.
+# Keyed off the PR number for pull_request events and the issue number for comment events,
+# so both event kinds collapse into the same group for the same PR.
+concurrency:
+  group: pr-agent-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # THE ORG SKIP RULES — the parity surface with cuioss/coderabbit's .coderabbit.yaml.
+    #
+    # pull_request branch:
+    #   - dependabot[bot]         dependency bumps, already gated by CI and auto-merge
+    #   - cuioss-release-bot[bot] consumer-propagation and workflow-SHA bumps
+    #   - skip-bot-review label   the shared org-wide manual opt-out
+    #   - fork pull requests      secrets are unavailable to them, so the token step could
+    #                             only fail; skipping keeps external PRs clean. Reviewing
+    #                             forks needs pull_request_target and a separate security
+    #                             review of that decision.
+    # issue_comment branch: an explicit slash-command from a human on a pull request. A
+    # deliberate /review overrides the skip label — someone is asking on purpose. Bot senders
+    # are excluded so the reviewer cannot retrigger itself off its own comment.
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false &&
+        github.event.pull_request.user.login != 'dependabot[bot]' &&
+        github.event.pull_request.user.login != 'cuioss-release-bot[bot]' &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-bot-review')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        github.event.sender.type != 'Bot' &&
+        startsWith(github.event.comment.body, '/')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # The reviewer posts under its own identity rather than github-actions[bot], so that
+      # downstream review-ingestion can attribute findings to it. `repositories` MUST include
+      # pr-agent-settings: without read access to it PR-Agent skips the central configuration
+      # silently, with no error in the log.
+      - name: Generate Review Token
+        id: review-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }},pr-agent-settings
+          owner: cuioss
+
+      # Pinned by IMAGE DIGEST, not by action ref. The action's Dockerfile is a bare
+      # `FROM pragent/pr-agent:github_action` — a floating tag in the former vendor's Docker
+      # Hub namespace — so pinning `The-PR-Agent/pr-agent@<sha>` would pin the wrapper while
+      # the executed code kept moving. Bump this digest deliberately, as a reviewed change.
+      # (Digest for the image published alongside upstream v0.39.0.)
+      - name: Review pull request
+        uses: docker://pragent/pr-agent@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
+        env:
+          GITHUB_TOKEN: ${{ steps.review-token.outputs.token }}
+          # Dotted keys are PR-Agent's documented env form; double underscores
+          # (GOOGLE_AI_STUDIO__GEMINI_API_KEY) are the documented equivalent.
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # The three tool toggles are the one deliberate exception to central configuration:
+          # they are caller inputs, so a single repository can opt into /improve without
+          # editing the org-wide file. Everything else comes from cuioss/pr-agent-settings.
+          github_action_config.auto_review: ${{ inputs.auto-review }}
+          github_action_config.auto_describe: ${{ inputs.auto-describe }}
+          github_action_config.auto_improve: ${{ inputs.auto-improve }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is the cuioss organization infrastructure repository containing:
 - Reusable GitHub Actions workflows for Maven builds and releases
 - Scripts to apply consistent repository settings and branch protection across all cuioss repos
-- Documentation for the cuioss-release-bot GitHub App and secrets management
+- Documentation for the cuioss-release-bot and cuioss-review-bot GitHub Apps and secrets management
+- Documentation for the automated PR reviewers (`docs/automatic-review/`)
 
 ## Key Commands
 
@@ -88,6 +89,7 @@ Centralized workflows called by individual cuioss repositories:
 | `reusable-maven-integration-tests.yml` | Integration/E2E tests with optional report deployment |
 | `reusable-scorecards.yml` | OpenSSF Scorecard security analysis |
 | `reusable-dependency-review.yml` | Dependency vulnerability scanning on PRs |
+| `reusable-pr-agent-review.yml` | Opt-in third automated PR reviewer (PR-Agent on Google Gemini); tuning is central in `cuioss/pr-agent-settings`, the skip rules are this workflow's `if:` guard |
 
 Caller repos pass explicit secret references (e.g., `SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}`). Organization-level secrets are inherited automatically.
 
@@ -105,7 +107,7 @@ Both use `config.json` to define:
 
 ### Secrets Model
 
-**Organization-level** (shared): `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `SONAR_TOKEN`
+**Organization-level** (shared): `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `SONAR_TOKEN`, `REVIEW_APP_ID`, `REVIEW_APP_PRIVATE_KEY`, `GEMINI_API_KEY`
 
 ## Git Workflow
 

--- a/docs/Secrets.adoc
+++ b/docs/Secrets.adoc
@@ -42,6 +42,18 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 |`SONAR_TOKEN`
 |SonarCloud authentication token
 |maven-build.yml
+
+|`REVIEW_APP_ID`
+|cuioss-review-bot GitHub App ID
+|pr-agent-review.yml
+
+|`REVIEW_APP_PRIVATE_KEY`
+|cuioss-review-bot private key (.pem)
+|pr-agent-review.yml
+
+|`GEMINI_API_KEY`
+|Google AI Studio API key for the PR-Agent reviewer (billing-enabled — the free tier is rate-limited and its traffic may be used for training)
+|pr-agent-review.yml
 |===
 
 === Why Organization-Level?
@@ -52,6 +64,7 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 * **Easier rotation** - Update once, applies everywhere
 * **Security** - Fewer copies of sensitive credentials
 * **SonarCloud** - Organization uses a single SonarCloud token for all projects
+* **Same review bot** - Single GitHub App and a single Gemini key for every repo that opts into automated PR-Agent review
 
 == npm Publishing (No Token Required)
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -155,6 +155,10 @@ NOTE: We intentionally do not use workflow-level `concurrency` with `cancel-in-p
 |`reusable-dependabot-auto-merge.yml`
 |Auto-merge Dependabot PRs for minor/patch updates
 |~20 → ~8
+
+|`reusable-pr-agent-review.yml`
+|Third automated PR reviewer (PR-Agent on Google Gemini)
+|~40 → ~14
 |===
 
 == Configuration via project.yml
@@ -907,6 +911,112 @@ For supply chain security, add a tiered cooldown to your `.github/dependabot.yml
 
 Add this block to each ecosystem entry in `dependabot.yml`.
 
+== PR Agent Review
+
+Third automated PR reviewer for the org, beside CodeRabbit and Sourcery, running the
+open-source PR-Agent on Google Gemini with a security-weighted charter.
+
+Adoption is *opt-in per repository*: a repo is reviewed only once it carries the caller
+workflow below.
+
+=== Basic Usage
+
+[source,yaml]
+----
+name: PR Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@6278bbd7280a6e94b4914aa9e8c61cf23ea1abbe # v0.13.0
+    secrets: inherit
+----
+
+=== Configuration
+
+Review tuning is *not* an input of this workflow. It lives centrally in
+https://github.com/cuioss/pr-agent-settings[`cuioss/pr-agent-settings`] (`.pr_agent.toml`),
+which PR-Agent reads as the organization-level settings file and merges beneath any
+repository-local `.pr_agent.toml`.
+
+The three tool toggles below are the deliberate exception, so that a single repository can
+opt into `/improve` without editing the org-wide file.
+
+=== Inputs
+
+[cols="1,1,1,2"]
+|===
+|Input |Type |Default |Description
+
+|`auto-review`
+|boolean
+|`true`
+|Run `/review` automatically on a new pull request
+
+|`auto-describe`
+|boolean
+|`false`
+|Run `/describe` automatically. Off by default — it rewrites the pull request description, which collides with generated PR bodies and the machine-readable blocks our automation reads out of them.
+
+|`auto-improve`
+|boolean
+|`false`
+|Run `/improve` automatically. Off by default — committable suggestions are already CodeRabbit's job, so enabling this duplicates findings and roughly doubles token cost per pull request.
+
+|`timeout-minutes`
+|number
+|`15`
+|Hard cap for the reviewer job
+|===
+
+=== Required Secrets
+
+All organization-level, so `secrets: inherit` is sufficient.
+
+[cols="1,2"]
+|===
+|Secret |Description
+
+|`REVIEW_APP_ID`
+|cuioss-review-bot App ID
+
+|`REVIEW_APP_PRIVATE_KEY`
+|cuioss-review-bot private key
+
+|`GEMINI_API_KEY`
+|Google AI Studio API key (billing-enabled)
+|===
+
+=== Skip Rules
+
+Enforced as the reusable workflow's job-level `if:` guard, *not* by PR-Agent configuration —
+its `ignore_pr_labels` / `ignore_pr_authors` settings are read only by its webhook servers and
+are ignored entirely in GitHub Action mode. A guarded-out pull request consumes no runner
+minutes and no tokens.
+
+* `dependabot[bot]` pull requests — gated by CI and auto-merge already.
+* `cuioss-release-bot[bot]` pull requests — consumer-propagation and workflow-SHA bumps.
+* Any pull request labelled `skip-bot-review` — the shared org-wide manual opt-out.
+* Fork pull requests — secrets are unavailable to them; reviewing forks would require
+`pull_request_target` and a separate security review of that decision.
+
+An explicit `/review` comment from a human overrides the skip label — someone is asking on
+purpose. There is no automatic re-review on push; request one with a `/review` comment.
+
+See xref:automatic-review/pr-agent.md[automatic-review/pr-agent.md] for the review anatomy and
+signal-vs-noise breakdown, and
+xref:cuioss-review-bot.adoc[cuioss-review-bot.adoc] for the App.
+
 == Examples
 
 See link:workflow-examples/[workflow-examples/] directory for complete caller workflow templates:
@@ -919,6 +1029,7 @@ See link:workflow-examples/[workflow-examples/] directory for complete caller wo
 * link:workflow-examples/pyprojectx-verify-caller.yml[pyprojectx-verify-caller.yml] - Python/pyprojectx verification
 * link:workflow-examples/npm-build-caller.yml[npm-build-caller.yml] - npm build
 * link:workflow-examples/npm-publish-caller.yml[npm-publish-caller.yml] - npm publish (OIDC trusted publishing)
+* link:workflow-examples/pr-agent-review-caller.yml[pr-agent-review-caller.yml] - PR Agent review (opt-in third reviewer)
 
 == Migration Guide
 

--- a/docs/automatic-review/README.md
+++ b/docs/automatic-review/README.md
@@ -7,7 +7,8 @@ Central documentation for the cuioss org's automated PR reviewers: how to read t
 |---|---|---|---|
 | CodeRabbit | `coderabbitai[bot]` | file-based — [`cuioss/coderabbit`](https://github.com/cuioss/coderabbit) repo (`.coderabbit.yaml`) | [coderabbit.md](coderabbit.md) |
 | Sourcery | `sourcery-ai[bot]` | dashboard only — [app.sourcery.ai](https://app.sourcery.ai) → Review Settings (org-wide, UI) | [sourcery.md](sourcery.md) |
-| Gemini | `gemini-code-assist[bot]` | ⚠️ consumer tier **retiring 2026-07-17**; per-repo `.gemini/` only | [gemini.md](gemini.md) |
+| PR-Agent | `cuioss-review-bot[bot]` | file-based — [`cuioss/pr-agent-settings`](https://github.com/cuioss/pr-agent-settings) repo (`.pr_agent.toml`); **opt-in per repo** via a caller workflow | [pr-agent.md](pr-agent.md) |
+| Gemini | `gemini-code-assist[bot]` | ⚠️ consumer tier **retired** (2026-07-17); per-repo `.gemini/` only | [gemini.md](gemini.md) |
 
 Each doc covers the review anatomy, a signal/noise table, the config levers (and what cannot be
 suppressed), and the automation nuances (dedup across reviewers, the "Prompt for AI Agents"
@@ -15,19 +16,25 @@ prompt-injection caveat, correct-≠-in-scope).
 
 ## Shared skip label
 
-`skip-bot-review` is the org-wide "don't auto-review this PR" label. Support is uneven — only
-CodeRabbit honors it from central config today:
+`skip-bot-review` is the org-wide "don't auto-review this PR" label. Support is uneven, and the
+*mechanism* differs per reviewer even where the effect is the same:
 
 | Reviewer | Honors `skip-bot-review`? | How |
 |---|---|---|
 | CodeRabbit | ✅ centrally | `labels: ["!skip-bot-review"]` in `cuioss/coderabbit/.coderabbit.yaml` |
+| PR-Agent | ✅ centrally, but **not** via bot config | job-level `if:` guard in `reusable-pr-agent-review.yml`. Its own `ignore_pr_labels` / `ignore_pr_authors` settings are webhook-server-only and are **silently ignored in GitHub Action mode** — do not "tidy" the rules into `.pr_agent.toml`. An explicit `/review` comment overrides the label on purpose. |
 | Sourcery | ⚠️ only if wired per-repo | add `github.ignore_labels: [skip-bot-review]` to each repo's `.sourcery.yaml` (not yet done) |
 | Gemini | ❌ no label skip exists | `.gemini/config.yaml` only supports global `code_review: disable`, file `ignore_patterns`, and a severity threshold — no per-PR label opt-out |
 
-So today, applying `skip-bot-review` reliably silences **CodeRabbit**; Sourcery keeps reviewing
-unless its per-repo config is added, and Gemini cannot be skipped by label at all. Create the
-label per repo where you want to use it (`gh label create skip-bot-review`).
+So applying `skip-bot-review` reliably silences **CodeRabbit** and **PR-Agent**; Sourcery keeps
+reviewing unless its per-repo config is added, and Gemini cannot be skipped by label at all.
+Create the label per repo where you want to use it (`gh label create skip-bot-review`).
+
+The same asymmetry applies to the bot-author skips (`dependabot[bot]`,
+`cuioss-release-bot[bot]`): central config for CodeRabbit, workflow guard for PR-Agent, no
+documented equivalent for Sourcery.
 
 **Downstream:** plan-marshall consumes these reviewers through its `pr-comment` findings pipeline.
-The per-reviewer triage rules live in plan-marshall at `.plan/auto-review/{code-rabbit,sourcery}.md`
-and link back here as the source of truth for signal/noise and configuration.
+The per-reviewer triage rules live in the `plan-marshall:automatic-review` skill under
+`standards/{bot_kind}.md`, each carrying a machine-readable registry block, and link back here as
+the source of truth for signal/noise and configuration.

--- a/docs/automatic-review/pr-agent.md
+++ b/docs/automatic-review/pr-agent.md
@@ -1,0 +1,121 @@
+# PR-Agent review: signal vs. noise
+
+How the cuioss org reads [PR-Agent](https://github.com/The-PR-Agent/pr-agent)
+(`cuioss-review-bot[bot]`) output, and which parts are worth acting on (especially for automated
+triage by Claude / plan-marshall).
+
+This is the **third** reviewer, beside CodeRabbit and Sourcery, and it is deliberately narrower
+than both — see [Charter](#charter).
+
+## Which PR-Agent
+
+The open-source project, self-hosted as a **GitHub Action**, on **Google Gemini** with our own
+key. Upstream is [`The-PR-Agent/pr-agent`](https://github.com/The-PR-Agent/pr-agent) — the
+community continuation of the project after the original vendor moved on; its own description
+states it is *not* the Qodo free tier. The hosted Qodo Merge SaaS was rejected because the model
+provider is not ours to choose on its free/basic tier.
+
+## Central config
+
+- **File-based and genuinely central** — [`cuioss/pr-agent-settings`](https://github.com/cuioss/pr-agent-settings)
+  (`.pr_agent.toml`), read from that repo's default branch. Better than CodeRabbit's equivalent
+  in two ways: the global file is merged *beneath* a repo-local `.pr_agent.toml` (no full
+  override), and a CI run re-reads it every invocation (no cache lag).
+- **Adoption is opt-in per repository** — a repo is reviewed only once it carries the
+  `pr-agent.yml` caller for `reusable-pr-agent-review.yml`.
+- **⚠ The skip rules are NOT in that file.** PR-Agent's `ignore_pr_labels` / `ignore_pr_authors` /
+  `ignore_pr_title` settings are read only by `should_process_pr_logic()`, which exists in its
+  webhook servers and **not** in `github_action_runner.py`. In Action mode they are dead config.
+  The org skip rules are the job-level `if:` guard in
+  [`reusable-pr-agent-review.yml`](../../.github/workflows/reusable-pr-agent-review.yml), which
+  keeps them central and costs zero runner minutes for a skipped PR.
+- Full mechanics, and the rest of the learnings from setting this up, are recorded in
+  [`pr-agent-settings/README.adoc`](https://github.com/cuioss/pr-agent-settings/blob/main/README.adoc) —
+  the source of truth; do not duplicate it here.
+
+Parity with the central CodeRabbit config:
+
+| Rule | CodeRabbit | PR-Agent |
+|---|---|---|
+| Skip `dependabot[bot]` | `ignore_usernames` in `.coderabbit.yaml` | workflow `if:` guard |
+| Skip `cuioss-release-bot[bot]` | `ignore_usernames` in `.coderabbit.yaml` | workflow `if:` guard |
+| Skip `skip-bot-review` label | `labels: ["!skip-bot-review"]` | workflow `if:` guard (an explicit `/review` comment overrides it) |
+| Fork PRs | reviewed | **not** reviewed — secrets are unavailable to them |
+| Re-review after a push | automatic incremental review | on demand only, via a `/review` comment |
+
+## Charter
+
+The consumer tier of Gemini Code Assist was the org's sharpest *security* reviewer, and its
+retirement left that gap (see [gemini.md](gemini.md)). A third general-purpose reviewer would
+mostly restate CodeRabbit and Sourcery, so this one is pointed at the gap instead:
+`require_security_review = true` plus security-weighted `extra_instructions`, with effort
+estimates, review labels, ticket analysis and help text switched off.
+
+It is also the only one of the three that reads `CLAUDE.md` / `AGENTS.md` as review context
+(`repo_context_files`), so it can review against documented project rules rather than generic
+expectations. Those files are read from the **default branch**, never from the PR head, so PR
+content cannot rewrite the reviewer's own instructions.
+
+## Anatomy of a review
+
+**One** GitHub surface, which is the biggest structural difference from the other two reviewers:
+
+1. **A single persistent issue comment**, headed `## PR Reviewer Guide 🔍`, containing an HTML
+   table of review fields. It is *updated in place* on re-review rather than reposted.
+
+With the central config, the fields that can appear are:
+
+| Field | Content |
+|---|---|
+| `⚡ Recommended focus areas for review` | The findings — a title plus a link to the relevant lines, capped at `num_max_findings` (5) |
+| `🔒 Security concerns` | Prose security assessment, or `No` |
+| `🧪 Relevant tests` | Whether the change carries tests |
+
+Suppressed centrally, and therefore *not* expected in our reviews: intro text, tool-usage help
+text, `⏱️ Estimated effort to review`, `🏅 Score`, `🎫 Relevant ticket` / ticket compliance,
+`🔀 Can be split`, and the security/effort review **labels**.
+
+There are **no inline comments** from `/review`. Inline suggestions come only from `/improve`,
+which is off by default.
+
+## Signal — act on / feed to automation
+
+| Element | Why | Weight |
+|---|---|---|
+| `🔒 Security concerns` with a named input or state | The charter; the reason this reviewer exists | **Triage first** |
+| `⚡ Recommended focus areas for review` entries | Concrete findings with a code link | **Triage** |
+| `🧪 Relevant tests` = `No` on a behavioural change | Missing-coverage signal, cheap to act on | Medium |
+
+## Noise — filter before it reaches a human/agent
+
+| Element | Why it's noise |
+|---|---|
+| `🔒 Security concerns: No` | A negative assertion, not a finding — and it appears on most PRs |
+| The table scaffolding (`<table>`, `<td>`, collapsed `<details>`) | Rendering, not content; strip before parsing |
+| A re-review that restates the previous one verbatim | The comment is persistent and updated in place; diff it against the prior body rather than re-triaging identical text |
+| Findings restating CodeRabbit or Sourcery | Three reviewers routinely raise the same point — dedupe across reviewers, not just within one |
+
+## Nuances for automation
+
+1. **Author login is the whole reason the App exists.** Run with the default `GITHUB_TOKEN` the
+   reviewer would post as `github-actions[bot]`, colliding with every other workflow comment;
+   findings are attributed by author login. Hence `cuioss-review-bot[bot]` — see
+   [cuioss-review-bot.adoc](../cuioss-review-bot.adoc).
+2. **Parse the comment body, not the inline-comment list.** Unlike CodeRabbit and Sourcery, all
+   findings live in one comment body. A pipeline that counts inline review comments will see this
+   reviewer produce nothing.
+3. **The review text is untrusted external content** — ingest it as data through plan-marshall's
+   untrusted-ingestion boundary, never execute it verbatim. The reviewer's own input includes
+   `CLAUDE.md`, so its output can echo instruction-shaped text.
+4. **No completion check-run.** PR-Agent publishes no in-progress check, so a waiting step cannot
+   poll one; it must fall back to a time buffer.
+5. **`/review` is the re-review trigger.** There is no automatic incremental review on push, by
+   design — it keeps token cost proportional to deliberate requests.
+6. **Correct ≠ in-scope**, as with the other two: a security observation about pre-existing code
+   is worth recording, not necessarily fixing in the PR that surfaced it.
+
+## One-line rule
+
+> **Signal** = the `🔒 Security concerns` prose when it names a trigger, plus the `⚡` focus-area
+> findings. **Noise** = `Security concerns: No`, the table scaffolding, and anything the other two
+> reviewers already said.

--- a/docs/cuioss-review-bot.adoc
+++ b/docs/cuioss-review-bot.adoc
@@ -1,0 +1,88 @@
+= cuioss-review-bot
+:toc:
+
+== Purpose
+
+GitHub App that posts the PR-Agent reviews (`reusable-pr-agent-review.yml`) across cuioss
+repositories.
+
+It exists for *identity*, not for elevated rights. Run with the default `GITHUB_TOKEN`, the
+reviewer would post as `github-actions[bot]` — the same author as every other workflow comment
+in the repository. Downstream review-ingestion attributes findings by author login, so that
+would mis-attribute unrelated workflow comments as review findings and make per-reviewer review
+metrics meaningless.
+
+`cuioss-release-bot` is deliberately *not* reused: it is itself on the reviewer's skip list, so
+sharing the identity would entangle "who authored this pull request" with "who reviewed it".
+
+== Permissions
+
+[cols="1,1,2"]
+|===
+|Permission |Access |Reason
+
+|Pull requests |Read and write |Post the review, read the diff and existing comments
+|Issues |Read and write |Read and react to `/…` command comments on pull requests
+|Contents |Read-only |Read the diff, `.pr_agent.toml`, and the repo-context files
+|Metadata |Read-only |Required for all GitHub Apps
+|===
+
+No ruleset bypass, and no write access to contents — the reviewer never pushes. The central
+configuration additionally sets `restricted_mode = true`, which makes PR-Agent skip any
+operation that would need elevated permissions.
+
+== Organization Secrets
+
+[cols="1,2"]
+|===
+|Secret |Description
+
+|`REVIEW_APP_ID`
+|The GitHub App ID (numeric)
+
+|`REVIEW_APP_PRIVATE_KEY`
+|The private key (`.pem` file contents)
+|===
+
+Set at: `https://github.com/organizations/cuioss/settings/secrets/actions`
+
+The reviewer also needs the organization secret `GEMINI_API_KEY` (Google AI Studio,
+billing-enabled) — see xref:Secrets.adoc[Secrets.adoc].
+
+== Installation
+
+Install the app *organization-wide*. This matters beyond convenience: PR-Agent reads its
+central configuration from `cuioss/pr-agent-settings`, and if the token cannot read that
+repository it skips the global configuration *silently, with no error*.
+
+== Token Usage
+
+[source,yaml]
+----
+- name: Generate Review Token
+  id: review-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ secrets.REVIEW_APP_ID }}
+    private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+    repositories: ${{ github.event.repository.name }},pr-agent-settings
+    owner: cuioss
+----
+
+`repositories` MUST list `pr-agent-settings` alongside the current repository:
+`actions/create-github-app-token` scopes its token to the current repository only by default,
+which would trigger the silent central-config skip described above.
+
+== Security Notes
+
+* Private key stored only in GitHub Secrets (never in repos).
+* No write access to contents, and no branch-protection bypass.
+* The token is scoped to two repositories per run, not to the whole installation.
+* Fork pull requests are not reviewed: secrets are unavailable to them, and reviewing them
+would require `pull_request_target`, which needs its own security review.
+
+== See also
+
+* xref:Workflows.adoc[Workflows.adoc] — the `PR Agent Review` reusable workflow.
+* xref:automatic-review/pr-agent.md[automatic-review/pr-agent.md] — review anatomy and signal vs. noise.
+* https://github.com/cuioss/pr-agent-settings[`cuioss/pr-agent-settings`] — the central configuration and the setup's recorded learnings.

--- a/docs/workflow-examples/pr-agent-review-caller.yml
+++ b/docs/workflow-examples/pr-agent-review-caller.yml
@@ -1,0 +1,38 @@
+# Example: PR Agent review workflow (third automated reviewer, on Google Gemini)
+# Copy this file to .github/workflows/pr-agent.yml in your repository.
+#
+# Adoption is opt-in: a repository is reviewed only once this workflow exists in it.
+# All tuning is central — cuioss/pr-agent-settings (.pr_agent.toml). Nothing is copied here.
+# Pin the reusable workflow at the release that first contains it (or later).
+#
+# Prerequisites (organization-wide, already in place):
+#   - cuioss-review-bot GitHub App installed org-wide
+#   - org secrets REVIEW_APP_ID, REVIEW_APP_PRIVATE_KEY, GEMINI_API_KEY
+#   - the skip-bot-review label present in the repository (gh label create skip-bot-review)
+
+name: PR Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  # Enables the on-demand slash commands (/review, /ask, /improve, /help) as PR comments.
+  # This is also how a re-review is requested after pushing fixes — there is deliberately no
+  # automatic re-review on every push.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@6278bbd7280a6e94b4914aa9e8c61cf23ea1abbe # v0.13.0
+    secrets: inherit
+    # Optional inputs (all have sensible defaults):
+    # with:
+    #   auto-review: true      # run /review on a new pull request
+    #   auto-describe: false   # rewrites the PR description — leave off
+    #   auto-improve: false    # duplicates CodeRabbit's suggestions — opt in per repo only
+    #   timeout-minutes: 15


### PR DESCRIPTION
Adds `reusable-pr-agent-review.yml`: the open-source [PR-Agent](https://github.com/The-PR-Agent/pr-agent) running on Google Gemini as a **third** automated reviewer beside CodeRabbit and Sourcery. Nothing is replaced, and adoption is **opt-in** — a repository is reviewed only once it carries the caller workflow.

Central tuning lives in the new **[cuioss/pr-agent-settings](https://github.com/cuioss/pr-agent-settings)** repo (`.pr_agent.toml`), which PR-Agent reads as its organization-level settings file and merges *beneath* any repo-local config. Its `README.adoc` documents the setup's learnings in full.

## Three findings that shaped this

**1. The skip rules cannot live in the central config.** PR-Agent's `ignore_pr_labels` / `ignore_pr_authors` / `ignore_pr_title` are consumed only by `should_process_pr_logic()`, which exists in its webhook servers (`servers/github_app.py`, `gitlab_webhook.py`, …) and **not** in `servers/github_action_runner.py`. In GitHub Action mode they are dead config — set them and every PR is reviewed anyway, with no error. So the org rules (`dependabot[bot]`, `cuioss-release-bot[bot]`, `skip-bot-review`) are the reusable workflow's job-level `if:` guard, which keeps them central *and* costs zero runner minutes for a skipped PR.

**2. Pinning the action would not pin the code.** The action's Dockerfile is a bare `FROM pragent/pr-agent:github_action` — a floating tag in the former vendor's Docker Hub namespace. So the reviewer image is pinned by **digest** instead. Digest bumps become a deliberate, reviewed change.

**3. The reviewer needs its own identity.** With the default `GITHUB_TOKEN` it would post as `github-actions[bot]`, colliding with every other workflow comment; downstream review-ingestion attributes findings by author login. Hence a dedicated `cuioss-review-bot` App, whose token is scoped to the PR repo **plus** `pr-agent-settings` — without that scope PR-Agent skips the central configuration silently.

## Configuration decisions

- `/review` only. `/describe` is off (it rewrites the PR description, colliding with generated PR bodies); `/improve` is off (committable suggestions are already CodeRabbit's job). Both are per-repo opt-in inputs.
- Security-weighted charter, filling the gap left by the retired consumer tier of Gemini Code Assist.
- Fork PRs are not reviewed — secrets are unavailable to them; that would need `pull_request_target` and its own security review.
- No automatic re-review on push; request one with a `/review` comment.

## Contents

| File | |
|---|---|
| `.github/workflows/reusable-pr-agent-review.yml` | the workflow, with the skip guard |
| `docs/workflow-examples/pr-agent-review-caller.yml` | opt-in caller template |
| `docs/cuioss-review-bot.adoc` | the App: permissions, secrets, token scoping |
| `docs/automatic-review/pr-agent.md` | review anatomy, signal vs. noise, automation nuances |
| `docs/automatic-review/README.md` | reviewer + skip-label tables (mechanism differs per reviewer) |
| `docs/Workflows.adoc`, `docs/Secrets.adoc`, `CLAUDE.md` | workflow/secret/architecture registries |

## Blocking prerequisites (org admin)

1. Create the `cuioss-review-bot` GitHub App — Pull requests RW, Issues RW, Contents RO, Metadata RO — installed **org-wide** (it must read `pr-agent-settings`).
2. Add org secrets `REVIEW_APP_ID`, `REVIEW_APP_PRIVATE_KEY`, `GEMINI_API_KEY` (billing-enabled AI Studio key).

Until then the workflow is inert: no repository calls it yet.

## Verification

`./pw verify workflow` green (262 tests); `check-internal-pinning.py` OK; internal ref SHAs still exactly two (release tag + release commit). Behavioural verification happens in the pilot — `plan-marshall` and `API-Sheriff` — once the App and secrets exist, with the decisive gate being: change a key in `pr-agent-settings`, touch nothing in the repo, and see the next review change.
