### PR TITLE
release: prepare 0.14.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.13.0
+  current-version: 0.14.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.14.0 for release.

Ships the opt-in PR-Agent reviewer workflow (#199) so consumer repos can pin `reusable-pr-agent-review.yml` at a release tag.