### PR TITLE
release: prepare 0.14.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.14.0
+  current-version: 0.14.1
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.14.1 for release.

Ships the PR-Agent published-review fail-closed gate (#202), so consumers can pin a reviewer workflow that reports failure instead of a green check with no review.