### PR TITLE
feat(pr-agent): run Gemini on Vertex AI via Workload Identity Federation

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -1,6 +1,8 @@
 name: PR Agent Review (Reusable)
 # Third automated PR reviewer for the cuioss org, beside CodeRabbit and Sourcery.
-# Runs the open-source PR-Agent (The-PR-Agent/pr-agent) on Google Gemini.
+# Runs the open-source PR-Agent (The-PR-Agent/pr-agent) on Google Gemini via Vertex AI,
+# authenticated keylessly through Workload Identity Federation — no Google credential is
+# stored in GitHub. Vertex also draws on the GCP free-trial credits, which AI Studio does not.
 #
 # Tuning lives centrally in cuioss/pr-agent-settings (.pr_agent.toml) — NOT here. Model and
 # tool tuning must never be set in this workflow's `env:`, because environment variables are
@@ -48,13 +50,19 @@ on:
         description: 'cuioss-review-bot private key (organization-level).'
         required: true
       GEMINI_API_KEY:
-        description: 'Google AI Studio API key, billing-enabled (organization-level).'
-        required: true
+        description: >-
+          Google AI Studio API key. OPTIONAL and unused on the Vertex AI path — kept only as an
+          escape hatch for a direct AI Studio run (point the model id in pr-agent-settings at a
+          `gemini/…` model instead of `vertex_ai/…` to use it).
+        required: false
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  # Mint the OIDC token that Workload Identity Federation exchanges for GCP credentials. This
+  # is what makes the Vertex AI path keyless — no Google credential is stored in GitHub.
+  id-token: write
 
 # One reviewer run per pull request; a superseded run is worth nothing and costs tokens.
 # Keyed off the PR number for pull_request events and the issue number for comment events,
@@ -126,6 +134,48 @@ jobs:
           repositories: ${{ github.event.repository.name }},pr-agent-settings
           owner: cuioss
 
+      # Keyless GCP auth: the job's OIDC token is exchanged for short-lived credentials for the
+      # reviewer service account. Nothing Google-side is stored in GitHub secrets — the pool,
+      # provider and service account are org variables, not credentials.
+      #
+      # The action writes the credentials file into $GITHUB_WORKSPACE precisely so Docker-based
+      # actions can read it (see the path translation below). No checkout is needed for that.
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_REVIEW_SERVICE_ACCOUNT }}
+
+      # TWO container boundaries have to be crossed by hand here, and getting either wrong
+      # produces an auth failure inside the reviewer that looks like nothing at all:
+      #
+      #   1. PATH — the action reports a HOST path
+      #      (/home/runner/work/{repo}/{repo}/gha-creds-*.json), but the reviewer is a Docker
+      #      action with the workspace mounted at /github/workspace. The host path does not
+      #      resolve inside the container, so only the basename is reusable.
+      #   2. ENV — a Docker action receives ONLY the variables named in its own `env:` block
+      #      (plus the standard GITHUB_*/RUNNER_* set). Exporting GOOGLE_APPLICATION_CREDENTIALS
+      #      to $GITHUB_ENV, as the auth action does, does NOT forward it into the container.
+      #      It has to be restated on the reviewer step below.
+      - name: Resolve credentials path inside the reviewer container
+        id: gcp-creds
+        env:
+          HOST_PATH: ${{ steps.gcp-auth.outputs.credentials_file_path }}
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          if [[ -z "$HOST_PATH" ]]; then
+            echo "::error::google-github-actions/auth produced no credentials file path"
+            exit 1
+          fi
+          # Fail early and by name. Without it the reviewer would reach the model call with no
+          # vertex_project, and the only symptom would be a review that never appears.
+          if [[ -z "$PROJECT_ID" ]]; then
+            echo "::error::organization variable GCP_PROJECT_ID is not set — the Vertex AI project is unknown"
+            exit 1
+          fi
+          echo "in_container=/github/workspace/$(basename "$HOST_PATH")" >> "$GITHUB_OUTPUT"
+
       # Timestamp taken BEFORE the reviewer runs, so the published-review gate below can tell
       # a review this run produced from a stale one left by an earlier run (the review comment
       # is persistent and updated in place, so mere existence proves nothing).
@@ -142,8 +192,21 @@ jobs:
         uses: docker://pragent/pr-agent@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
           GITHUB_TOKEN: ${{ steps.review-token.outputs.token }}
+          # Vertex AI credentials, translated to the in-container path (see above). LiteLLM
+          # picks these up as Application Default Credentials.
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-creds.outputs.in_container }}
           # Dotted keys are PR-Agent's documented env form; double underscores
-          # (GOOGLE_AI_STUDIO__GEMINI_API_KEY) are the documented equivalent.
+          # (VERTEXAI__VERTEX_PROJECT) are the documented equivalent. pr-agent reads these in
+          # litellm_ai_handler.py and hands them to LiteLLM as vertex_project / vertex_location.
+          #
+          # These two are deployment IDENTITY, not review tuning, so they are org variables
+          # rather than entries in the public pr-agent-settings repo — one place to change, and
+          # the GCP project id stays out of a public config file. Everything that IS review
+          # tuning (model, fallbacks, charter, noise toggles) remains central there.
+          VERTEXAI.VERTEX_PROJECT: ${{ vars.GCP_PROJECT_ID }}
+          VERTEXAI.VERTEX_LOCATION: ${{ vars.GCP_VERTEX_LOCATION || 'global' }}
+          # Unused on the Vertex path; harmless when unset. Present so a repo can fall back to
+          # AI Studio by changing only the model id in pr-agent-settings.
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           # The three tool toggles are the one deliberate exception to central configuration:
           # they are caller inputs, so a single repository can opt into /improve without

--- a/docs/Secrets.adoc
+++ b/docs/Secrets.adoc
@@ -52,9 +52,42 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 |pr-agent-review.yml
 
 |`GEMINI_API_KEY`
-|Google AI Studio API key for the PR-Agent reviewer (billing-enabled — the free tier is rate-limited and its traffic may be used for training)
+|*Optional escape hatch only.* Google AI Studio API key for the PR-Agent reviewer. Unused on the default Vertex AI path — see the variables below
 |pr-agent-review.yml
 |===
+
+== Organization-Level Variables
+
+Not credentials, so they are **variables**, not secrets. Set at:
+`https://github.com/organizations/cuioss/settings/variables/actions`
+
+[cols="1,2,1"]
+|===
+|Variable |Purpose |Used By
+
+|`GCP_WIF_PROVIDER`
+|Full resource name of the Workload Identity provider the reviewer authenticates through (`projects/{number}/locations/global/workloadIdentityPools/{pool}/providers/{provider}`)
+|pr-agent-review.yml
+
+|`GCP_REVIEW_SERVICE_ACCOUNT`
+|Email of the service account the reviewer impersonates (needs `roles/aiplatform.user`)
+|pr-agent-review.yml
+
+|`GCP_PROJECT_ID`
+|GCP project serving Vertex AI
+|pr-agent-review.yml
+
+|`GCP_VERTEX_LOCATION`
+|Vertex AI location. Optional — defaults to `global`, where the newest Gemini models are served
+|pr-agent-review.yml
+|===
+
+=== Why Keyless?
+
+The reviewer reaches Gemini through **Vertex AI with Workload Identity Federation**: the
+workflow's OIDC token is exchanged for short-lived GCP credentials at run time. No Google
+credential is stored in GitHub, so there is nothing to rotate or leak. It also draws on the GCP
+free-trial credits, which AI Studio does not.
 
 === Why Organization-Level?
 
@@ -64,7 +97,7 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 * **Easier rotation** - Update once, applies everywhere
 * **Security** - Fewer copies of sensitive credentials
 * **SonarCloud** - Organization uses a single SonarCloud token for all projects
-* **Same review bot** - Single GitHub App and a single Gemini key for every repo that opts into automated PR-Agent review
+* **Same review bot** - Single GitHub App for every repo that opts into automated PR-Agent review
 
 == npm Publishing (No Token Required)
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -914,7 +914,9 @@ Add this block to each ecosystem entry in `dependabot.yml`.
 == PR Agent Review
 
 Third automated PR reviewer for the org, beside CodeRabbit and Sourcery, running the
-open-source PR-Agent on Google Gemini with a security-weighted charter.
+open-source PR-Agent on Google Gemini with a security-weighted charter. Gemini is reached
+through *Vertex AI* with *Workload Identity Federation* — keyless, and it draws on the GCP
+free-trial credits.
 
 Adoption is *opt-in per repository*: a repo is reviewed only once it carries the caller
 workflow below.
@@ -935,6 +937,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write   # required — Workload Identity Federation for Vertex AI
 
 jobs:
   review:
@@ -994,7 +997,29 @@ All organization-level, so `secrets: inherit` is sufficient.
 |cuioss-review-bot private key
 
 |`GEMINI_API_KEY`
-|Google AI Studio API key (billing-enabled)
+|*Optional.* AI Studio API key — an escape hatch, unused on the default Vertex AI path
+|===
+
+=== Required Variables
+
+Organization *variables*, not secrets — none of them is a credential, because Vertex AI is
+reached keylessly. See xref:Secrets.adoc[Secrets.adoc].
+
+[cols="1,2"]
+|===
+|Variable |Description
+
+|`GCP_WIF_PROVIDER`
+|Workload Identity provider resource name
+
+|`GCP_REVIEW_SERVICE_ACCOUNT`
+|Service account the reviewer impersonates (`roles/aiplatform.user`)
+
+|`GCP_PROJECT_ID`
+|GCP project serving Vertex AI
+
+|`GCP_VERTEX_LOCATION`
+|Optional Vertex location; defaults to `global`
 |===
 
 === Skip Rules
@@ -1088,6 +1113,9 @@ All action versions are pinned centrally in this repo:
 
 |`SonarSource/sonarqube-scan-action`
 |v7.0.0
+
+|`google-github-actions/auth`
+|v3.0.0
 |===
 
 To update versions: Edit the reusable workflows here, all repos inherit automatically.

--- a/docs/cuioss-review-bot.adoc
+++ b/docs/cuioss-review-bot.adoc
@@ -46,8 +46,9 @@ operation that would need elevated permissions.
 
 Set at: `https://github.com/organizations/cuioss/settings/secrets/actions`
 
-The reviewer also needs the organization secret `GEMINI_API_KEY` (Google AI Studio,
-billing-enabled) — see xref:Secrets.adoc[Secrets.adoc].
+The reviewer reaches Gemini through Vertex AI with Workload Identity Federation, so it needs no
+Google credential in GitHub — only the organization *variables* `GCP_WIF_PROVIDER`,
+`GCP_REVIEW_SERVICE_ACCOUNT` and `GCP_PROJECT_ID`. See xref:Secrets.adoc[Secrets.adoc].
 
 == Installation
 

--- a/docs/workflow-examples/pr-agent-review-caller.yml
+++ b/docs/workflow-examples/pr-agent-review-caller.yml
@@ -7,7 +7,9 @@
 #
 # Prerequisites (organization-wide, already in place):
 #   - cuioss-review-bot GitHub App installed org-wide
-#   - org secrets REVIEW_APP_ID, REVIEW_APP_PRIVATE_KEY, GEMINI_API_KEY
+#   - org secrets REVIEW_APP_ID, REVIEW_APP_PRIVATE_KEY
+#   - org variables GCP_WIF_PROVIDER, GCP_REVIEW_SERVICE_ACCOUNT, GCP_PROJECT_ID
+#     (Vertex AI is reached keylessly, so these are variables, not secrets)
 #   - the skip-bot-review label present in the repository (gh label create skip-bot-review)
 
 name: PR Agent Review
@@ -25,6 +27,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  # Required: mints the OIDC token Workload Identity Federation exchanges for the short-lived
+  # GCP credentials the reviewer uses to reach Gemini on Vertex AI.
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
Switches the reviewer from AI Studio to **Vertex AI**, authenticated **keylessly**.

Two reasons: Vertex consumes the GCP free-trial credits (AI Studio does not — the first live run died on `429 Your prepayment credits are depleted`), and Workload Identity Federation removes the last long-lived Google credential from GitHub. The job's OIDC token is exchanged for short-lived credentials at run time; `GEMINI_API_KEY` becomes optional, kept only as an escape hatch for a direct AI Studio run.

## Why this works cleanly

pr-agent's Vertex path is config-driven — `litellm_ai_handler.py:190-194` reads `VERTEXAI.VERTEX_PROJECT` / `VERTEXAI.VERTEX_LOCATION` and hands them to LiteLLM — while authentication itself is plain Application Default Credentials. So the model config stays central in `pr-agent-settings` (now `vertex_ai/gemini-3.5-pro`, fallback `vertex_ai/gemini-3.5-flash`).

Project and location are org **variables**, not entries in the public settings repo: they are deployment identity rather than review tuning, and this keeps the GCP project id out of a public file.

## ⚠ Two container boundaries crossed by hand

Either one left implicit produces an auth failure *inside* the reviewer that looks like nothing at all:

1. **Path** — `google-github-actions/auth` writes the credentials file into `$GITHUB_WORKSPACE` (deliberately, so Docker actions can read it) but reports a **host** path. The reviewer is a Docker action with that workspace mounted at `/github/workspace`, so only the basename is reusable.
2. **Environment** — a Docker action receives **only** the variables named in its own `env:` block, plus the standard `GITHUB_*`/`RUNNER_*` set. The earlier run log confirms this. So exporting `GOOGLE_APPLICATION_CREDENTIALS` to `$GITHUB_ENV`, as the auth action does, does **not** forward it into the container; it is restated on the reviewer step.

Both are documented at the point of use, and in [`pr-agent-settings/README.adoc`](https://github.com/cuioss/pr-agent-settings/blob/main/README.adoc).

A missing `GCP_PROJECT_ID` now fails **by name** in a preflight step, rather than surfacing as a review that never appears.

## Caller change

Callers must add `id-token: write`. Both pilot callers are updated alongside this.

## New org variables (no new secrets)

`GCP_WIF_PROVIDER`, `GCP_REVIEW_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`, optional `GCP_VERTEX_LOCATION` (default `global`).

## Verification

`./pw verify workflow` green; `check-internal-pinning.py` OK; new external action `google-github-actions/auth` SHA-pinned at v3.0.0 and added to the action-versions table. End-to-end verification is the pilot re-run once the GCP-side WIF pool exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR reviews can now authenticate with Vertex AI using keyless GitHub OIDC and short-lived Google Cloud credentials.
  * Added support for configuring the Google Cloud project, service account, identity provider, and Vertex AI location.
  * Gemini API key authentication remains available as an optional fallback.

* **Documentation**
  * Updated setup guides and workflow examples with the new authentication requirements and configuration details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->