### PR TITLE
release: prepare 0.15.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.14.1
+  current-version: 0.15.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.15.0 for release.

Ships the PR-Agent Vertex AI / Workload Identity Federation migration (#204): keyless GCP auth, free-trial credits, and `id-token: write` as a new caller requirement.