### PR TITLE
chore(pr-agent): drop the AI Studio passthrough

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -49,12 +49,8 @@ on:
       REVIEW_APP_PRIVATE_KEY:
         description: 'cuioss-review-bot private key (organization-level).'
         required: true
-      GEMINI_API_KEY:
-        description: >-
-          Google AI Studio API key. OPTIONAL and unused on the Vertex AI path — kept only as an
-          escape hatch for a direct AI Studio run (point the model id in pr-agent-settings at a
-          `gemini/…` model instead of `vertex_ai/…` to use it).
-        required: false
+      # These two are the ONLY secrets this workflow takes. Gemini is reached through Vertex AI
+      # with Workload Identity Federation, so there is no Google credential to store.
 
 permissions:
   contents: read
@@ -205,9 +201,12 @@ jobs:
           # tuning (model, fallbacks, charter, noise toggles) remains central there.
           VERTEXAI.VERTEX_PROJECT: ${{ vars.GCP_PROJECT_ID }}
           VERTEXAI.VERTEX_LOCATION: ${{ vars.GCP_VERTEX_LOCATION || 'global' }}
-          # Unused on the Vertex path; harmless when unset. Present so a repo can fall back to
-          # AI Studio by changing only the model id in pr-agent-settings.
-          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # No GOOGLE_AI_STUDIO.GEMINI_API_KEY here, deliberately. Carrying it "just in case"
+          # advertised an AI Studio fallback that does not exist — the org secret is gone, so
+          # the value would resolve to an empty string and a `gemini/…` model id in
+          # pr-agent-settings would fail at the model call. Restoring that path means
+          # re-creating the secret AND re-adding this line; leaving a dead reference here would
+          # only hide that.
           # The three tool toggles are the one deliberate exception to central configuration:
           # they are caller inputs, so a single repository can opt into /improve without
           # editing the org-wide file. Everything else comes from cuioss/pr-agent-settings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,9 @@ Both use `config.json` to define:
 
 ### Secrets Model
 
-**Organization-level** (shared): `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `SONAR_TOKEN`, `REVIEW_APP_ID`, `REVIEW_APP_PRIVATE_KEY`, `GEMINI_API_KEY`
+**Organization-level** (shared): `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `SONAR_TOKEN`, `REVIEW_APP_ID`, `REVIEW_APP_PRIVATE_KEY`
+
+**Organization-level variables** (not credentials): `GCP_WIF_PROVIDER`, `GCP_REVIEW_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`, `GCP_VERTEX_LOCATION` — the PR-Agent reviewer reaches Vertex AI keylessly via Workload Identity Federation, so it stores no Google credential.
 
 ## Git Workflow
 

--- a/docs/Secrets.adoc
+++ b/docs/Secrets.adoc
@@ -51,10 +51,10 @@ Set at: `https://github.com/organizations/cui-oss/settings/secrets/actions`
 |cuioss-review-bot private key (.pem)
 |pr-agent-review.yml
 
-|`GEMINI_API_KEY`
-|*Optional escape hatch only.* Google AI Studio API key for the PR-Agent reviewer. Unused on the default Vertex AI path — see the variables below
-|pr-agent-review.yml
 |===
+
+The PR-Agent reviewer needs no Google credential: Gemini is reached through Vertex AI with
+Workload Identity Federation, configured by the variables below.
 
 == Organization-Level Variables
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -995,10 +995,10 @@ All organization-level, so `secrets: inherit` is sufficient.
 
 |`REVIEW_APP_PRIVATE_KEY`
 |cuioss-review-bot private key
-
-|`GEMINI_API_KEY`
-|*Optional.* AI Studio API key — an escape hatch, unused on the default Vertex AI path
 |===
+
+These two are the only secrets. No Google credential is required — Vertex AI is reached
+keylessly through Workload Identity Federation, configured by the variables below.
 
 === Required Variables
 


### PR DESCRIPTION
The `GEMINI_API_KEY` org secret has been deleted, so the workflow's `GOOGLE_AI_STUDIO.GEMINI_API_KEY` passthrough advertised a route that **could not work**: the value resolved to an empty string, and a `gemini/…` model id in `pr-agent-settings` would have failed at the model call.

Functionally it was harmless — pr-agent tests the value for truthiness and an empty string is falsy. But it is the same class of defect this workflow was built to route around: **config claiming a capability it does not have**, exactly like PR-Agent's `ignore_pr_*` settings in Action mode. A future reader would have believed they could switch back to AI Studio by editing one model id.

Removes the secret declaration and the env line, and states at both sites that reviving the AI Studio route means re-creating the secret **and** re-adding the line — deliberately, together.

`REVIEW_APP_ID` and `REVIEW_APP_PRIVATE_KEY` are now the only secrets this workflow takes. `CLAUDE.md` also gains the org-variables list alongside the secrets model, which it was missing.

Paired with the same cleanup in [cuioss/pr-agent-settings](https://github.com/cuioss/pr-agent-settings).

Verification: `./pw verify workflow` green (262 passed); `check-internal-pinning.py` OK; no live `GEMINI_API_KEY` reference remains anywhere in `.github/`, `docs/` or `CLAUDE.md` — only the comments explaining its deliberate absence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that PR-Agent review requires only the review app ID and private key secrets.
  * Removed references to the deprecated Gemini API key.
  * Documented keyless Vertex AI access through Workload Identity Federation.
  * Added the required Google Cloud configuration variables for this setup.
* **Chores**
  * Updated the review workflow to remove the unused Gemini credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->