### PR TITLE
release: prepare 0.15.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.0
+  current-version: 0.15.1
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.15.1 for release.

Ships the removal of the PR-Agent AI Studio passthrough (#206) — REVIEW_APP_ID and REVIEW_APP_PRIVATE_KEY are now the reviewer's only secrets.