### PR TITLE
release: prepare 0.15.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.1
+  current-version: 0.15.2
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.15.2 for release.

Ships the corrected PR-Agent gate (#208): it now keys on the reviewer step's structured output rather than a published comment, so a clean review that deliberately posts nothing no longer fails the job.