### PR TITLE
fix(pr-agent): restrict command-triggered runs to trusted commenters

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -79,11 +79,24 @@ jobs:
     #                             only fail; skipping keeps external PRs clean. Reviewing
     #                             forks needs pull_request_target and a separate security
     #                             review of that decision.
-    # issue_comment branch: an explicit slash-command from a human on a pull request. A
-    # deliberate /review overrides the skip label — someone is asking on purpose. Bot senders
-    # are excluded so the reviewer cannot retrigger itself off its own comment. The commands
-    # are matched individually rather than by a bare leading "/": any other slash-prefixed
-    # comment would otherwise start a runner for a command PR-Agent does not implement.
+    # issue_comment branch: an explicit slash-command on a pull request. This path is
+    # PRIVILEGED — unlike `pull_request`, an `issue_comment` event always runs in the base-repo
+    # context with full access to secrets and the OIDC token, even when the pull request comes
+    # from a fork. So the gate here is on WHO may trigger it, not on which pull request:
+    #
+    #   - author_association restricts triggering to OWNER / MEMBER / COLLABORATOR. This is
+    #     what keeps an outside contributor from spending our Vertex budget, or steering a run
+    #     that holds a PR-write App token, by commenting on their own fork's pull request.
+    #     It also subsumes the fork case the pull_request branch handles structurally.
+    #   - sender.type != 'Bot' keeps the reviewer from retriggering itself off its own comment.
+    #   - The commands are matched individually rather than by a bare leading "/", so an
+    #     unrelated slash-prefixed comment cannot start a runner.
+    #
+    # The org PR skips are deliberately NOT mirrored here. A trusted maintainer typing /review
+    # on a dependabot pull request, or on one labelled skip-bot-review, is asking on purpose —
+    # an explicit human request outranks a blanket automation skip. That override is safe only
+    # because of the author_association gate above; without it, the skips would be bypassable
+    # by anyone who can comment.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -95,6 +108,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         github.event.sender.type != 'Bot' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
         (
           startsWith(github.event.comment.body, '/review') ||
           startsWith(github.event.comment.body, '/improve') ||

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -942,7 +942,9 @@ permissions:
 jobs:
   review:
     uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@83b3ab36e40dedbeda0ee74ac71876183b70b649 # v0.15.2
-    secrets: inherit
+    secrets:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
+      REVIEW_APP_PRIVATE_KEY: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
 ----
 
 === Configuration
@@ -984,7 +986,8 @@ opt into `/improve` without editing the org-wide file.
 
 === Required Secrets
 
-All organization-level, so `secrets: inherit` is sufficient.
+Both are organization-level. Map them explicitly rather than using `secrets: inherit`, which
+would expose every caller secret to the reviewer for no reason.
 
 [cols="1,2"]
 |===

--- a/docs/workflow-examples/pr-agent-review-caller.yml
+++ b/docs/workflow-examples/pr-agent-review-caller.yml
@@ -34,7 +34,12 @@ permissions:
 jobs:
   review:
     uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@83b3ab36e40dedbeda0ee74ac71876183b70b649 # v0.15.2
-    secrets: inherit
+    # Map only what the reviewer needs. `secrets: inherit` would hand it every caller secret
+    # (GPG keys, Sonatype credentials, SONAR_TOKEN, …) for no reason; these two are the whole
+    # requirement, because Vertex AI is reached keylessly.
+    secrets:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
+      REVIEW_APP_PRIVATE_KEY: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
     # Optional inputs (all have sensible defaults):
     # with:
     #   auto-review: true      # run /review on a new pull request


### PR DESCRIPTION
Two security findings CodeRabbit raised on the pilot caller ([plan-marshall#1001](https://github.com/cuioss/plan-marshall/pull/1001)), both valid.

## 1. The `issue_comment` path was privileged and ungated

Unlike `pull_request`, an `issue_comment` event **always runs in the base-repo context with full secrets and the OIDC token** — even when the pull request comes from a fork. The guard only required "target is a PR, sender is not a bot, body starts with a known command", so any account able to comment could spend the Vertex budget and steer a run holding a PR-write App token.

Fixed by gating on **who** may trigger rather than on which pull request:

```yaml
contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
```

That also subsumes the fork case the `pull_request` branch handles structurally — an outside contributor on their own fork is not a collaborator.

**Where I disagree with the suggested fix:** CodeRabbit proposed mirroring all four PR skips onto the comment path (fork, `dependabot[bot]`, `cuioss-release-bot[bot]`, `skip-bot-review`). I deliberately did not. A maintainer typing `/review` on a Dependabot PR, or on one labelled `skip-bot-review`, is asking **on purpose**, and an explicit human request should outrank a blanket automation skip. What made that override unsafe was not the override itself but the missing trust gate. With `author_association` in place the override is defensible — and the comment in the workflow says so, so the two don't get separated later.

## 2. `secrets: inherit` over-shared

Now that Vertex AI is keyless, the reviewer needs exactly `REVIEW_APP_ID` and `REVIEW_APP_PRIVATE_KEY`. `inherit` handed it every caller secret — GPG keys, Sonatype credentials, `SONAR_TOKEN` — for no reason. The caller docs and example now map the two explicitly.

## Verification

`./pw verify workflow` green (262 passed); `check-internal-pinning.py` OK.

Note the `author_association` guard is genuinely hard to self-test — proving the negative needs a comment from a non-collaborator. The positive case is covered by the next `/review` a maintainer posts.
