### PR TITLE
release: prepare 0.15.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.2
+  current-version: 0.15.3
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.15.3 for release.

Ships the PR-Agent command-trigger trust gate (#210): author_association restricts /review and friends to OWNER/MEMBER/COLLABORATOR, closing a privileged path that any commenter could reach, plus explicit secret mapping in the caller docs.