### PR TITLE
fix(pr-agent-review): stop the reviewer cancelling itself and its own verification

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -60,12 +60,39 @@ permissions:
   # is what makes the Vertex AI path keyless — no Google credential is stored in GitHub.
   id-token: write
 
-# One reviewer run per pull request; a superseded run is worth nothing and costs tokens.
-# Keyed off the PR number for pull_request events and the issue number for comment events,
-# so both event kinds collapse into the same group for the same PR.
+# The unit of grouping is the TRIGGER, not the pull request — and nothing is ever cancelled.
+#
+# Both properties are here because the obvious shape (one group per PR, cancel-in-progress: true)
+# was live and actively destructive. Concurrency is evaluated at WORKFLOW level, before the job's
+# `if:` guard, so every comment on a pull request claimed the group and cancelled whatever was
+# running — including comments the guard then skipped. Two observed failures on one pull request:
+# a maintainer's /review was killed four seconds later by an unrelated "@coderabbitai review"
+# comment (and so silently did nothing), and the run that DID publish a review cancelled ITSELF,
+# because its own review comment fired issue_comment three seconds after it posted.
+#
+# That self-cancellation is worse than a wasted run: the reviewer step had already succeeded and
+# published, but the fail-closed gate at the end of this job was skipped, so a review reached the
+# pull request while the step that verifies the reviewer actually worked never ran. A workflow
+# whose reason for existing is a truthful signal must not be able to cancel its own verification.
+#
+#   - Comment runs are keyed per COMMENT: each is a distinct, explicit human request (/review is
+#     not /ask), so they must not collapse into one group. Dropping one because another arrived
+#     is never right.
+#   - pull_request runs are keyed per PR: opened/reopened/ready_for_review are redundant
+#     notifications about the same state, so grouping them is correct.
+#   - cancel-in-progress stays FALSE, matching the org-wide policy in docs/Workflows.adoc
+#     ("we intentionally do not use workflow-level concurrency with cancel-in-progress").
+#
+# The accepted cost is that two reviews requested seconds apart can run concurrently and both
+# update the persistent review comment, last write winning. That is strictly better than silently
+# discarding a maintainer's explicit request.
+#
+# The group expression is deliberately kept on ONE line: a folded YAML scalar preserves the line
+# breaks of more-indented continuation lines, which would embed newlines inside the ${{ }} it is
+# supposed to be evaluating.
 concurrency:
-  group: pr-agent-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  group: pr-agent-${{ github.repository }}-${{ github.event_name == 'issue_comment' && format('comment-{0}', github.event.comment.id) || format('pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: false
 
 jobs:
   review:

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1041,6 +1041,25 @@ minutes and no tokens.
 An explicit `/review` comment from a human overrides the skip label — someone is asking on
 purpose. There is no automatic re-review on push; request one with a `/review` comment.
 
+=== Concurrency
+
+Nothing is ever cancelled (`cancel-in-progress: false`), per the org-wide policy noted above.
+The concurrency group is keyed on the *trigger*, not the pull request:
+
+* Comment-triggered runs group per comment id. Each slash-command is a distinct explicit
+request, so two of them must never collapse into one group.
+* `pull_request` runs group per pull request number, since `opened` / `reopened` /
+`ready_for_review` are redundant notifications about the same state.
+
+This shape is load-bearing, not incidental. Concurrency is evaluated at workflow level, *before*
+the job's `if:` guard, so a group keyed on the pull request alone lets any comment — including
+ones the guard then skips, and including the reviewer's own published review — cancel a review
+that is mid-flight. That leaves the worst possible outcome: the reviewer publishes, but the
+fail-closed step that verifies it actually produced a review is skipped.
+
+The accepted trade-off is that two reviews requested seconds apart may run concurrently and both
+update the persistent review comment, last write winning.
+
 See xref:automatic-review/pr-agent.md[automatic-review/pr-agent.md] for the review anatomy and
 signal-vs-noise breakdown, and
 xref:cuioss-review-bot.adoc[cuioss-review-bot.adoc] for the App.


### PR DESCRIPTION
## Problem

`reusable-pr-agent-review.yml` grouped concurrency on the pull request with
`cancel-in-progress: true`. Concurrency is evaluated at **workflow** level, before the job's
`if:` guard, so *every* comment on a pull request claimed the group and cancelled whatever was
running — including comments the guard then skipped.

Both failure modes were observed live on `cuioss/API-Sheriff#103`, the first pull request where
this reviewer actually published:

| Run | What happened |
|---|---|
| `30196237055` | A maintainer's `/review` was cancelled 4s later by an unrelated `@coderabbitai review` comment. It silently did nothing — it looked like the trigger was broken. |
| `30196441156` | The run that **published** the review cancelled *itself*: its own review comment fired `issue_comment` 3s after it posted. |

The self-cancellation is the serious one. In `30196441156`:

```
9  Review pull request                        → success   (review published 09:27:15Z)
10 Verify the reviewer actually produced a review → SKIPPED
```

A review reached the pull request while the fail-closed step that proves the reviewer actually
worked never ran, and the run's conclusion is `cancelled` — indistinguishable from a genuine
abort. A workflow whose entire purpose is producing a truthful signal must not be able to cancel
its own verification.

This also violated the org-wide policy already documented in `docs/Workflows.adoc`: *"We
intentionally do not use workflow-level `concurrency` with `cancel-in-progress`."*

## Fix

Both axes, because either alone leaves a hole:

- **Group on the trigger, not the pull request.** Comment runs group per `comment.id` — each
  slash-command is a distinct explicit human request, and `/review` is not `/ask`. `pull_request`
  runs keep grouping per PR number, since `opened` / `reopened` / `ready_for_review` are
  redundant notifications about one state.
- **`cancel-in-progress: false`**, restoring compliance with the documented org policy.

Grouping alone would still let GitHub cancel a *pending* run when a burst of comments arrives
(#103 had three in one second), silently dropping a maintainer's `/review`. Disabling
cancellation alone would still serialize every comment behind an in-flight review.

## Trade-off accepted

Two reviews requested seconds apart can now run concurrently and both update the persistent
review comment, last write winning. That is strictly better than silently discarding an explicit
request.

## Notes

The group expression is deliberately one line: a folded YAML scalar (`>-`) preserves the line
breaks of more-indented continuation lines, which would embed newlines inside the `${{ }}` being
evaluated. Verified by parsing the file after the change.

## Verification

- `./pw verify workflow` — 262 passed, SUCCESS
- `workflow-scripts/check-internal-pinning.py` — OK
- Workflow YAML parsed post-change; group resolves to a single-line expression, `cancel-in-progress: false`

Behavioural confirmation needs a release and a caller bump — after merge, the check is that a
`/review` issued while another review is in flight produces two runs that both complete, and that
the publishing run's `Verify the reviewer actually produced a review` step executes rather than
being skipped.

## Docs

`docs/Workflows.adoc` gains a *Concurrency* subsection under PR Agent Review recording the shape
and why it is load-bearing, so it does not get "tidied" back to the obvious form.
