### PR TITLE
release: prepare 0.15.4

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.3
+  current-version: 0.15.4
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bumps `release.current-version` so the Release workflow can tag **v0.15.4**.

Ships #212 — the PR-Agent reviewer concurrency fix. The reviewer's concurrency group was keyed on the pull request with `cancel-in-progress: true`, and concurrency is evaluated before the job's `if:` guard, so any comment cancelled an in-flight review. Observed live on `API-Sheriff#103` (a maintainer's `/review` killed by an unrelated comment; the publishing run cancelling itself, leaving its fail-closed verification step skipped) and again on `plan-marshall#1008` with no comment trigger involved at all.

Now: group per `comment.id` for `issue_comment`, per PR number for `pull_request`, and `cancel-in-progress: false` per the org-wide policy in `docs/Workflows.adoc`.

Consumer callers are bumped automatically by the release workflow across the 21 repos in `.github/project.yml`.