### PR TITLE
fix(pr-agent-review): verify /review runs too, not only automatic ones

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.4
+  current-version: 0.15.5
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)

--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -272,15 +272,34 @@ jobs:
       # to suppress "No major issues detected" noise), and the review comment is persistent and
       # updated in place, so a stale one from an earlier run would satisfy a naive check.
       #
-      # Scoped to auto-review pull_request runs: a comment-triggered /ask or /help writes no
-      # review output, and auto-review: false produces none by definition.
+      # SCOPE — every run that should produce review output, and only those:
+      #
+      #   - pull_request runs, when auto-review is on (auto-review: false produces none by
+      #     definition).
+      #   - issue_comment runs whose command is /review. This path matters MORE than the
+      #     automatic one, not less: there is deliberately no `synchronize` trigger, so /review
+      #     is the ONLY way to re-review after a push, and plan-marshall's automatic-review skill
+      #     posts it programmatically on a loop-back. Leaving it ungated meant the re-review path
+      #     could report green while every model call failed — the same false green this gate
+      #     exists to prevent, through a different door.
+      #
+      # Scoping is by COMMAND, not by event, because /ask and /help write no review output and
+      # would fail a gate keyed on the event alone. /improve and /describe write their own output
+      # keys ('improve' / 'describe'), not 'review'.
+      #
+      # Verified against upstream v0.39.0 before narrowing: github_action_output() is a no-op
+      # unless github_action_config.enable_output is truthy, and github_action_runner.py:63
+      # defaults it to True and sets it BEFORE the event branch — so the output is written on the
+      # comment path exactly as on the pull_request path.
       - name: Verify the reviewer actually produced a review
-        if: ${{ github.event_name == 'pull_request' && inputs.auto-review }}
+        if: >-
+          ${{ (github.event_name == 'pull_request' && inputs.auto-review)
+              || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/review')) }}
         env:
           REVIEW_OUTPUT: ${{ steps.review.outputs.review }}
           GH_TOKEN: ${{ steps.review-token.outputs.token }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           STARTED_AT: ${{ steps.started.outputs.at }}
         run: |
           if [[ -z "$REVIEW_OUTPUT" ]]; then

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1041,6 +1041,20 @@ minutes and no tokens.
 An explicit `/review` comment from a human overrides the skip label — someone is asking on
 purpose. There is no automatic re-review on push; request one with a `/review` comment.
 
+=== Verification
+
+PR-Agent cannot report its own failure: its action runner catches exceptions and exits `0`, so a
+run whose every model call failed reports success. A fail-closed step therefore verifies the
+reviewer's own structured output (`steps.review.outputs.review`), which is written before the
+publish decision — never a published comment, since a clean review deliberately publishes nothing
+and the comment is persistent and updated in place.
+
+The check covers both paths that produce review output: automatic `pull_request` runs, and
+`/review` comments. It is scoped by command rather than by event, because `/ask` and `/help`
+write no review output at all. The `/review` path is the one consumers depend on for a
+re-review — including automation that posts the command programmatically — so leaving it
+unverified would have reproduced the same false green on the path that matters most.
+
 === Concurrency
 
 Nothing is ever cancelled (`cancel-in-progress: false`), per the org-wide policy noted above.


### PR DESCRIPTION
## Problem

The fail-closed gate was scoped to `github.event_name == 'pull_request' && inputs.auto-review`, so every comment-triggered `/review` **skipped** it. PR-Agent exits 0 even when every model call fails, so a `/review` whose model calls all failed reported green — the same false green the gate exists to prevent, reached through a different door.

Observed on `TokenSheriff#607`: a `/review` returned `success` with `Verify the reviewer actually produced a review → skipped`, and no comment. "Ran and found nothing" and "failed silently" were indistinguishable.

That path is the one that matters most. There is deliberately no `synchronize` trigger, so `/review` is the *only* re-review mechanism — and plan-marshall's `automatic-review` skill posts it programmatically on a loop-back. Automation was about to depend on an unverified signal.

## Fix

Gate both paths that produce review output:

```yaml
if: >-
  ${{ (github.event_name == 'pull_request' && inputs.auto-review)
      || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/review')) }}
```

Scoped by **command**, not by event: `/ask` and `/help` write no review output and would fail a gate keyed on the event alone; `/improve` and `/describe` write their own output keys.

Also fixes `PR_NUMBER` in that step, which read only `github.event.pull_request.number` and was therefore empty on comment runs.

## Premise check

The change rests entirely on the output existing on the comment path, so I verified it against upstream v0.39.0 rather than assuming:

- `utils.py:1258` — `github_action_output()` is a **no-op** unless `github_action_config.enable_output` is truthy, and it is absent from `configuration.toml`.
- `github_action_runner.py:63` — the action runner defaults it to `True` and sets it **before** the event branch.

So `steps.review.outputs.review` is written on comment runs exactly as on `pull_request` runs. Had the first file been the whole story, this change would have failed every `/review`.

## Verification

- `./pw verify workflow` — SUCCESS
- Workflow YAML re-parsed; the `if:` and `PR_NUMBER` expressions resolve as intended

Behavioural confirmation after release: a `/review` should now execute the verify step rather than skip it.

## Release

Bumps `current-version` to 0.15.5 in the same PR — this is a single logical release, and splitting it into a separate `release: prepare` PR would only add a round trip.