### PR TITLE
fix(dependabot): land auto-merge under the merge queue via an App identity

### DIFF
--- a/.github/workflows/dependabot-sweeper.yml
+++ b/.github/workflows/dependabot-sweeper.yml
@@ -1,0 +1,57 @@
+name: Dependabot Sweeper
+
+# Merges the Dependabot PRs that reusable-dependabot-auto-merge.yml labelled as
+# eligible, across every cuioss repository at once.
+#
+# This runs here rather than in each consumer repo on purpose: a Dependabot-
+# triggered workflow only ever holds GITHUB_TOKEN, cannot read Actions secrets,
+# and -- because GitHub starts no workflow runs for GITHUB_TOKEN events -- cannot
+# land a PR through a required merge queue. A scheduled run in this repository is
+# not Dependabot-triggered, so it can mint a cuioss-release-bot App token and
+# merge as an identity whose events do start the merge_group check runs.
+
+on:
+  schedule:
+    # Every 15 minutes -- the upper bound on how long an eligible, green
+    # Dependabot PR waits before it is enqueued.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Report what would be merged without merging'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-sweeper
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Generate Release Token
+        id: release-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: cuioss
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Sweep labelled Dependabot PRs
+        run: python3 workflow-scripts/sweep-dependabot-prs.py ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}

--- a/.github/workflows/dependabot-sweeper.yml
+++ b/.github/workflows/dependabot-sweeper.yml
@@ -33,6 +33,10 @@ concurrency:
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    # Below the 15-minute cron period: a stuck run is killed before the next
+    # one is due, so runs can never stack up behind it under
+    # cancel-in-progress: false.
+    timeout-minutes: 10
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -1,5 +1,18 @@
 name: Dependabot Auto-merge (Reusable)
-# Reusable workflow to auto-merge Dependabot PRs for minor/patch updates.
+# Reusable workflow that marks Dependabot PRs eligible for auto-merge.
+#
+# This workflow only LABELS. The merge itself is performed by the org-central
+# sweeper (.github/workflows/dependabot-sweeper.yml in cuioss-organization),
+# which runs on a schedule under the cuioss-release-bot App identity.
+#
+# Why the split: a workflow triggered by Dependabot only ever holds GITHUB_TOKEN,
+# and GitHub does not start workflow runs for events created by GITHUB_TOKEN.
+# Under a required merge queue that makes the token structurally unable to land a
+# PR -- either the queue entry never receives its merge_group check runs and is
+# dropped when check_response_timeout_minutes expires, or the auto-merge request
+# is recorded and never converts into a queue entry at all. Both leave a green,
+# mergeable PR sitting open indefinitely. An App token is not GITHUB_TOKEN and is
+# not subject to that rule, so the merge has to happen under one.
 #
 # Consumer repos add a thin caller workflow:
 #   on:
@@ -21,6 +34,11 @@ on:
         type: string
         required: false
         default: 'minor,patch'
+      automerge-label:
+        description: 'Label applied to eligible PRs. The org sweeper merges exactly this label.'
+        type: string
+        required: false
+        default: 'automerge'
 
 permissions:
   contents: read
@@ -30,7 +48,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
 
     steps:
@@ -45,7 +63,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-merge minor and patch updates
+      # update-type is the HIGHEST semver step across the PR, so a grouped update
+      # containing one major is excluded by the same condition that excludes a
+      # single major.
+      - name: Mark minor and patch updates eligible for auto-merge
         if: >-
           (
             (contains(inputs.allowed-update-types, 'patch') && steps.metadata.outputs.update-type == 'version-update:semver-patch') ||
@@ -55,7 +76,13 @@ jobs:
             inputs.allowed-dependency-pattern == '' ||
             contains(steps.metadata.outputs.dependency-names, inputs.allowed-dependency-pattern)
           )
-        run: gh pr merge --auto --squash "$PR_URL"
+        # Adding an existing label needs only pull-requests: write, which every
+        # caller already grants. Creating one would need issues: write, so the
+        # label is provisioned per repo by setup-repo-settings.py instead --
+        # a missing label fails this step loudly rather than merging nothing
+        # quietly.
+        run: gh pr edit "$PR_URL" --add-label "$LABEL"
         env:
+          LABEL: ${{ inputs.automerge-label }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Centralized workflows called by individual cuioss repositories:
 | `reusable-maven-integration-tests.yml` | Integration/E2E tests with optional report deployment |
 | `reusable-scorecards.yml` | OpenSSF Scorecard security analysis |
 | `reusable-dependency-review.yml` | Dependency vulnerability scanning on PRs |
+| `reusable-dependabot-auto-merge.yml` | Labels eligible Dependabot PRs; the merge itself is done by `dependabot-sweeper.yml` here, under a `cuioss-release-bot` App token — a Dependabot-triggered workflow holds only `GITHUB_TOKEN`, whose events start no workflow runs, so it cannot land a PR through a merge queue |
 | `reusable-pr-agent-review.yml` | Opt-in third automated PR reviewer (PR-Agent on Google Gemini); tuning is central in `cuioss/pr-agent-settings`, the skip rules are this workflow's `if:` guard |
 
 Caller repos pass explicit secret references (e.g., `SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}`). Organization-level secrets are inherited automatically.

--- a/branch-protection/config.json
+++ b/branch-protection/config.json
@@ -20,6 +20,7 @@
         "required_review_thread_resolution": false
       },
       "require_status_checks": {
+        "$comment": "strict_required_status_checks_policy is forced OFF for repos in merge_queue.merge_queue_repos: the queue brings each entry up to date itself, and requiring it beforehand keeps a PR from ever reading as ready.",
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_checks": []

--- a/branch-protection/setup-branch-protection.py
+++ b/branch-protection/setup-branch-protection.py
@@ -88,11 +88,19 @@ def get_app_id(org: str, bypass_actor_name: str) -> str | None:
     return None
 
 
+def uses_merge_queue(config: dict, repo: str | None) -> bool:
+    """Report whether a repo is on the org-managed merge queue."""
+    if not repo:
+        return False
+    return repo in config.get("merge_queue", {}).get("merge_queue_repos", [])
+
+
 def build_ruleset_payload(
     config: dict,
     bypass_actor_id: str,
     required_checks_override: list[str] | None = None,
     required_reviews_override: int | None = None,
+    merge_queue_enabled: bool = False,
 ) -> dict:
     """Build ruleset JSON payload.
 
@@ -101,6 +109,8 @@ def build_ruleset_payload(
         bypass_actor_id: GitHub App ID for bypass actor
         required_checks_override: Override for required status checks (None = use config)
         required_reviews_override: Override for required reviews count (None = use config)
+        merge_queue_enabled: Repo is on the org-managed merge queue, which
+            forces strict_required_status_checks_policy off (see below)
     """
     ruleset = config["ruleset"]
     rules_config = ruleset["rules"]
@@ -153,12 +163,19 @@ def build_ruleset_payload(
             },
         })
 
-    # Add status checks rule only if there are required checks
+    # Add status checks rule only if there are required checks.
+    # On a merge-queue repo, "require branches to be up to date" must be off:
+    # the queue is what brings an entry up to date, so demanding it beforehand
+    # makes readiness depend on a condition the queue itself is responsible for
+    # satisfying -- and readiness is what auto-merge waits on.
+    strict = rules_config["require_status_checks"]["strict_required_status_checks_policy"]
+    if merge_queue_enabled:
+        strict = False
     if required_checks:
         payload["rules"].append({
             "type": "required_status_checks",
             "parameters": {
-                "strict_required_status_checks_policy": rules_config["require_status_checks"]["strict_required_status_checks_policy"],
+                "strict_required_status_checks_policy": strict,
                 "do_not_enforce_on_create": rules_config["require_status_checks"].get("do_not_enforce_on_create", False),
                 "required_status_checks": [
                     {"context": check}
@@ -271,7 +288,10 @@ def compute_diff(
     """Compute diff between current and desired ruleset."""
     ruleset_name = config["ruleset"]["name"]
     existing = get_existing_ruleset(org, repo, ruleset_name)
-    desired = build_ruleset_payload(config, bypass_actor_id, required_checks_override, required_reviews_override)
+    desired = build_ruleset_payload(
+        config, bypass_actor_id, required_checks_override, required_reviews_override,
+        merge_queue_enabled=uses_merge_queue(config, repo),
+    )
 
     diff = {
         "repository": f"{org}/{repo}",
@@ -311,7 +331,10 @@ def apply_ruleset(
     ruleset_name = config["ruleset"]["name"]
     log_info(f"Processing {org}/{repo}...")
 
-    payload = build_ruleset_payload(config, bypass_actor_id, required_checks_override, required_reviews_override)
+    payload = build_ruleset_payload(
+        config, bypass_actor_id, required_checks_override, required_reviews_override,
+        merge_queue_enabled=uses_merge_queue(config, repo),
+    )
     payload_json = json.dumps(payload)
 
     existing_id = get_existing_ruleset_id(org, repo, ruleset_name)
@@ -358,7 +381,10 @@ def verify_ruleset(
         log_error("  Could not fetch ruleset for verification")
         return False
 
-    desired = build_ruleset_payload(config, bypass_actor_id, required_checks_override, required_reviews_override)
+    desired = build_ruleset_payload(
+        config, bypass_actor_id, required_checks_override, required_reviews_override,
+        merge_queue_enabled=uses_merge_queue(config, repo),
+    )
 
     # Normalize both for comparison
     current_normalized = normalize_ruleset_for_comparison(existing)

--- a/build.py
+++ b/build.py
@@ -30,6 +30,7 @@ MODULES = {
         "workflow-scripts/consumer_update_utils.py",
         "workflow-scripts/update-consumer-dependency.py",
         "workflow-scripts/check-maven-central.py",
+        "workflow-scripts/sweep-dependabot-prs.py",
     ],
     "repo-admin": [
         "repo-settings/setup-repo-settings.py",
@@ -49,6 +50,7 @@ ALL_SOURCES = [
     "workflow-scripts/consumer_update_utils.py",
     "workflow-scripts/update-consumer-dependency.py",
     "workflow-scripts/check-maven-central.py",
+    "workflow-scripts/sweep-dependabot-prs.py",
     "repo-settings/setup-repo-settings.py",
     "branch-protection/setup-branch-protection.py",
 ]

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -914,6 +914,20 @@ The caller uses the default `GITHUB_TOKEN` — it only labels. The App credentia
 
 === Merge Queue Repositories
 
+Every workflow that produces a *required status check* must also subscribe to the `merge_group` event:
+
+[source,yaml]
+----
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+----
+
+Without it the queue entry never receives those check runs, waits out `check_response_timeout_minutes`, and is dropped — taking any auto-merge request with it.
+
+The caller templates for the workflows that produce required checks — Maven build, Maven integration tests, npm build, pyprojectx verify — carry the trigger. Templates for workflows that never produce a required check (dependency review, scorecards, PR-Agent, releases, the Dependabot labeller) deliberately do not. A repo that promotes a new check to *required* has to add the trigger to that workflow itself.
+
 Repos on the org-managed merge queue must not also require *branches to be up to date before merging*. The queue is what brings an entry up to date; requiring it beforehand makes a PR's readiness depend on a condition the queue itself satisfies, and readiness is what the sweeper waits on. `setup-branch-protection.py` enforces this: any repo listed in `merge_queue.merge_queue_repos` gets `strict_required_status_checks_policy: false`.
 
 === Recommended: Dependabot Cooldown

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -153,7 +153,7 @@ NOTE: We intentionally do not use workflow-level `concurrency` with `cancel-in-p
 |~80 → ~12
 
 |`reusable-dependabot-auto-merge.yml`
-|Auto-merge Dependabot PRs for minor/patch updates
+|Mark Dependabot PRs for minor/patch updates eligible for auto-merge (the org sweeper performs the merge)
 |~20 → ~8
 
 |`reusable-pr-agent-review.yml`
@@ -873,7 +873,18 @@ jobs:
       pull-requests: write
 ----
 
-By default, this workflow auto-merges **all** Dependabot PRs for **minor and patch** updates. Major updates require manual review.
+By default, this marks **all** Dependabot PRs for **minor and patch** updates as eligible. Major updates require manual review. For a grouped update, eligibility is decided by the *highest* semver step in the group, so a group containing one major update is excluded.
+
+=== How the Merge Happens
+
+Auto-merge runs in two parts, in two different identities:
+
+. **This workflow labels.** It runs in the consumer repo on the Dependabot PR, evaluates the update-type policy, and applies the `automerge` label. It never merges.
+. **The org sweeper merges.** `dependabot-sweeper.yml` in `cuioss-organization` runs every 15 minutes, mints a `cuioss-release-bot` App token, and merges every labelled PR that GitHub reports as ready. On a merge-queue repo that enqueues; elsewhere it merges directly.
+
+The split is not stylistic. A Dependabot-triggered workflow only ever holds `GITHUB_TOKEN`, and GitHub starts no workflow runs for events created by `GITHUB_TOKEN`. Under a required merge queue that makes the token structurally unable to land a PR: either the queue entry never receives its `merge_group` check runs and is dropped when `check_response_timeout_minutes` expires, or the auto-merge request is recorded and never converts into a queue entry. Both leave a green, mergeable PR open indefinitely. An App token is not `GITHUB_TOKEN` and is not subject to that rule.
+
+A Dependabot-triggered workflow also cannot read Actions secrets, so it cannot mint the App token itself — which is why the sweeper is scheduled centrally rather than added to each consumer repo.
 
 === Inputs (Optional)
 
@@ -890,11 +901,20 @@ By default, this workflow auto-merges **all** Dependabot PRs for **minor and pat
 |string
 |`minor,patch`
 |Comma-separated semver update types to auto-merge (`major`, `minor`, `patch`)
+
+|`automerge-label`
+|string
+|`automerge`
+|Label applied to eligible PRs. The org sweeper merges exactly this label.
 |===
 
 === No Secrets Required
 
-This workflow uses the default `GITHUB_TOKEN`. It auto-merges Dependabot PRs that match the configured update types and dependency pattern.
+The caller uses the default `GITHUB_TOKEN` — it only labels. The App credentials live with the sweeper in `cuioss-organization`.
+
+=== Merge Queue Repositories
+
+Repos on the org-managed merge queue must not also require *branches to be up to date before merging*. The queue is what brings an entry up to date; requiring it beforehand makes a PR's readiness depend on a condition the queue itself satisfies, and readiness is what the sweeper waits on. `setup-branch-protection.py` enforces this: any repo listed in `merge_queue.merge_queue_repos` gets `strict_required_status_checks_policy: false`.
 
 === Recommended: Dependabot Cooldown
 

--- a/docs/workflow-examples/npm-build-caller.yml
+++ b/docs/workflow-examples/npm-build-caller.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required for the GitHub merge queue: `build / conclusion` is a required
+  # status check, and without this trigger the queue entry never receives it,
+  # waits out check_response_timeout_minutes, and is dropped.
+  merge_group:
 
 permissions:
   contents: read

--- a/docs/workflow-examples/pyprojectx-verify-caller.yml
+++ b/docs/workflow-examples/pyprojectx-verify-caller.yml
@@ -8,6 +8,11 @@ on:
     branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
   pull_request:
     branches: [main]
+  # Required for the GitHub merge queue: `verify / conclusion` is a required
+  # status check, and without this trigger the queue entry never receives it,
+  # waits out check_response_timeout_minutes, and is dropped.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/repo-settings/config.json
+++ b/repo-settings/config.json
@@ -29,5 +29,13 @@
     "squash_merge_commit_title": "PR_TITLE",
     "squash_merge_commit_message": "PR_BODY"
   },
+  "labels": [
+    {
+      "$comment": "Applied by reusable-dependabot-auto-merge.yml and consumed by dependabot-sweeper.yml. That workflow holds only pull-requests: write and cannot create labels, so it must exist before the first eligible PR.",
+      "name": "automerge",
+      "color": "0e8a16",
+      "description": "Eligible for automated merge by the cuioss dependabot sweeper"
+    }
+  ],
   "repositories": []
 }

--- a/repo-settings/setup-repo-settings.py
+++ b/repo-settings/setup-repo-settings.py
@@ -425,9 +425,45 @@ def verify_settings(org: str, repo: str, config: dict) -> bool:
             log_error(f"  ✗ {key}: expected {desired}, got {actual}")
             all_passed = False
 
+    # Verify labels. A missing automerge label silently disables Dependabot
+    # auto-merge for the whole repo -- the labelling workflow cannot create one
+    # -- so an absent label has to fail the run, not just warn.
+    if not verify_labels(org, repo, config):
+        all_passed = False
+
     # Check sidebar sections (advisory only — does not affect pass/fail)
     check_sidebar_warnings(org, repo, config)
 
+    return all_passed
+
+
+def verify_labels(org: str, repo: str, config: dict) -> bool:
+    """Verify every configured label exists on the repository."""
+    labels = config.get("labels", [])
+    if not labels:
+        return True
+
+    result = run_gh(
+        ["label", "list", "--repo", f"{org}/{repo}", "--limit", "200", "--json", "name"],
+        check=False,
+    )
+    if result.returncode != 0:
+        log_error("  ✗ labels: could not list labels for verification")
+        return False
+
+    try:
+        existing = {entry["name"] for entry in json.loads(result.stdout or "[]")}
+    except json.JSONDecodeError:
+        log_error("  ✗ labels: could not parse label list")
+        return False
+
+    all_passed = True
+    for label in labels:
+        if label["name"] in existing:
+            log_info(f"  ✓ label: {label['name']}")
+        else:
+            log_error(f"  ✗ label: {label['name']} is missing")
+            all_passed = False
     return all_passed
 
 

--- a/repo-settings/setup-repo-settings.py
+++ b/repo-settings/setup-repo-settings.py
@@ -285,6 +285,33 @@ def apply_repo_settings(org: str, repo: str, config: dict) -> None:
         log_warn("  ⚠ Some settings may require admin access")
 
 
+def apply_labels(org: str, repo: str, config: dict) -> None:
+    """Provision org-managed labels.
+
+    reusable-dependabot-auto-merge.yml runs under GITHUB_TOKEN with only
+    pull-requests: write, which can attach an existing label but cannot create
+    one. Provisioning the label here keeps that workflow's permissions minimal.
+    """
+    labels = config.get("labels", [])
+    if not labels:
+        return
+
+    log_info("Applying labels...")
+    for label in labels:
+        args = [
+            "label", "create", label["name"],
+            "--repo", f"{org}/{repo}",
+            "--color", label["color"],
+            "--description", label.get("description", ""),
+            "--force",
+        ]
+        result = run_gh(args, check=False)
+        if result.returncode == 0:
+            log_info(f"  ✓ Label '{label['name']}'")
+        else:
+            log_warn(f"  ⚠ Label '{label['name']}' failed: {result.stderr.strip()}")
+
+
 def apply_security_settings(org: str, repo: str, config: dict) -> None:
     """Apply security settings."""
     security = config["security"]
@@ -499,6 +526,7 @@ def main() -> None:
     # Single repo apply mode
     if args.repo and args.apply:
         apply_repo_settings(org, args.repo, config)
+        apply_labels(org, args.repo, config)
         apply_security_settings(org, args.repo, config)
         if not verify_settings(org, args.repo, config):
             log_error("Verification failed: some settings were not applied correctly")
@@ -516,6 +544,7 @@ def main() -> None:
     failed_repos: list[str] = []
     for repo in config["repositories"]:
         apply_repo_settings(org, repo, config)
+        apply_labels(org, repo, config)
         apply_security_settings(org, repo, config)
         if not verify_settings(org, repo, config):
             failed_repos.append(repo)

--- a/test/repo-admin/test_setup_branch_protection.py
+++ b/test/repo-admin/test_setup_branch_protection.py
@@ -342,6 +342,70 @@ class TestMergeQueuePayloadBuild:
         assert module.LEGACY_MERGE_QUEUE_NAME == "plan-marshall-merge-queue"
 
 
+class TestStrictPolicyUnderMergeQueue:
+    """Test that the queue and 'require branches up to date' never both apply.
+
+    The queue is what brings an entry up to date. Demanding it beforehand makes
+    a PR's readiness depend on a condition the queue itself satisfies, and
+    readiness is what auto-merge waits on -- so the PR never becomes mergeable.
+    """
+
+    def _config(self) -> dict:
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+
+    def _strict_of(self, payload: dict) -> bool | None:
+        for rule in payload["rules"]:
+            if rule["type"] == "required_status_checks":
+                return rule["parameters"]["strict_required_status_checks_policy"]
+        return None
+
+    def test_merge_queue_repo_gets_strict_off(self):
+        module = _load_module()
+        payload = module.build_ruleset_payload(
+            self._config(), "2753519",
+            required_checks_override=["build / conclusion"],
+            merge_queue_enabled=True,
+        )
+        assert self._strict_of(payload) is False
+
+    def test_non_queue_repo_keeps_config_value(self):
+        module = _load_module()
+        config = self._config()
+        payload = module.build_ruleset_payload(
+            config, "2753519",
+            required_checks_override=["build / conclusion"],
+            merge_queue_enabled=False,
+        )
+        expected = config["ruleset"]["rules"]["require_status_checks"][
+            "strict_required_status_checks_policy"
+        ]
+        assert self._strict_of(payload) is expected
+
+    def test_uses_merge_queue_reads_the_repo_list(self):
+        module = _load_module()
+        config = self._config()
+        listed = config["merge_queue"]["merge_queue_repos"][0]
+        assert module.uses_merge_queue(config, listed) is True
+        assert module.uses_merge_queue(config, "not-a-queue-repo") is False
+
+    def test_uses_merge_queue_handles_missing_repo(self):
+        module = _load_module()
+        assert module.uses_merge_queue(self._config(), None) is False
+
+    def test_every_queue_repo_resolves_to_strict_off(self):
+        """Guard the wiring, not just the flag: config list -> payload."""
+        module = _load_module()
+        config = self._config()
+        for repo in config["merge_queue"]["merge_queue_repos"]:
+            payload = module.build_ruleset_payload(
+                config, "2753519",
+                required_checks_override=["build / conclusion"],
+                merge_queue_enabled=module.uses_merge_queue(config, repo),
+            )
+            assert self._strict_of(payload) is False, repo
+
+
 class TestMergeQueueArgValidation:
     """Test CLI validation for the merge-queue flags."""
 

--- a/test/repo-admin/test_setup_repo_settings.py
+++ b/test/repo-admin/test_setup_repo_settings.py
@@ -338,3 +338,49 @@ class TestHomepageConfigSchema:
         with open(CONFIG_PATH) as f:
             config = json.load(f)
         assert config["homepage"]["include_releases"] is True
+
+
+class TestLabelProvisioning:
+    """Test org-managed label provisioning.
+
+    reusable-dependabot-auto-merge.yml can attach the automerge label but not
+    create it, so the label has to be provisioned here or the first eligible
+    Dependabot PR fails to be marked.
+    """
+
+    def test_config_defines_automerge_label(self):
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        names = [label["name"] for label in config["labels"]]
+        assert "automerge" in names
+
+    def test_automerge_label_has_color_and_description(self):
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        label = next(x for x in config["labels"] if x["name"] == "automerge")
+        assert label["color"]
+        assert label["description"]
+
+    def test_apply_labels_creates_each_configured_label(self):
+        mod = _load_module()
+        config = {"labels": [{"name": "automerge", "color": "0e8a16", "description": "d"}]}
+        with patch.object(mod, "run_gh", return_value=MagicMock(returncode=0)) as gh:
+            mod.apply_labels("cuioss", "test-repo", config)
+        args = gh.call_args[0][0]
+        assert args[:3] == ["label", "create", "automerge"]
+        assert "--force" in args
+        assert "--repo" in args and args[args.index("--repo") + 1] == "cuioss/test-repo"
+
+    def test_apply_labels_noop_without_labels(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh") as gh:
+            mod.apply_labels("cuioss", "test-repo", {})
+        gh.assert_not_called()
+
+    def test_apply_labels_survives_failure(self):
+        """A failing label must warn, not abort the whole settings run."""
+        mod = _load_module()
+        config = {"labels": [{"name": "automerge", "color": "0e8a16", "description": "d"}]}
+        failure = MagicMock(returncode=1, stderr="nope")
+        with patch.object(mod, "run_gh", return_value=failure):
+            mod.apply_labels("cuioss", "test-repo", config)

--- a/test/repo-admin/test_setup_repo_settings.py
+++ b/test/repo-admin/test_setup_repo_settings.py
@@ -377,10 +377,68 @@ class TestLabelProvisioning:
             mod.apply_labels("cuioss", "test-repo", {})
         gh.assert_not_called()
 
-    def test_apply_labels_survives_failure(self):
-        """A failing label must warn, not abort the whole settings run."""
+    def test_apply_labels_does_not_abort_on_failure(self):
+        """Apply warns and continues; verify_labels is what fails the run."""
         mod = _load_module()
         config = {"labels": [{"name": "automerge", "color": "0e8a16", "description": "d"}]}
         failure = MagicMock(returncode=1, stderr="nope")
         with patch.object(mod, "run_gh", return_value=failure):
             mod.apply_labels("cuioss", "test-repo", config)
+
+
+class TestLabelVerification:
+    """Test that a missing label fails the settings run.
+
+    A missing automerge label silently disables Dependabot auto-merge for the
+    whole repo, so it must not pass verification.
+    """
+
+    def _config(self):
+        return {"labels": [{"name": "automerge", "color": "0e8a16", "description": "d"}]}
+
+    def test_present_label_passes(self):
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout='[{"name":"automerge"}]')
+        with patch.object(mod, "run_gh", return_value=listing):
+            assert mod.verify_labels("cuioss", "test-repo", self._config()) is True
+
+    def test_missing_label_fails(self):
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout='[{"name":"bug"}]')
+        with patch.object(mod, "run_gh", return_value=listing):
+            assert mod.verify_labels("cuioss", "test-repo", self._config()) is False
+
+    def test_list_failure_fails(self):
+        """Unverifiable is not the same as verified -- do not pass on error."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=MagicMock(returncode=1, stdout="")):
+            assert mod.verify_labels("cuioss", "test-repo", self._config()) is False
+
+    def test_malformed_listing_fails(self):
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout="not json")
+        with patch.object(mod, "run_gh", return_value=listing):
+            assert mod.verify_labels("cuioss", "test-repo", self._config()) is False
+
+    def test_no_labels_configured_passes(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh") as gh:
+            assert mod.verify_labels("cuioss", "test-repo", {}) is True
+        gh.assert_not_called()
+
+    def test_verify_settings_fails_on_missing_label(self):
+        """The gate has to be wired into verify_settings, not just exist."""
+        mod = _load_module()
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+        current = {
+            "features": config["features"],
+            "merge": config["merge"],
+        }
+        with (
+            patch.object(mod, "get_current_settings", return_value=current),
+            patch.object(mod, "get_current_security_settings", return_value=config["security"]),
+            patch.object(mod, "verify_labels", return_value=False),
+            patch.object(mod, "check_sidebar_warnings"),
+        ):
+            assert mod.verify_settings("cuioss", "test-repo", config) is False

--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -148,6 +148,55 @@ class TestFindCandidates:
         assert "--limit" in args and args[args.index("--limit") + 1] == "50"
 
 
+class TestReadPrState:
+    """Test how the merge-readiness fields are read.
+
+    isInMergeQueue is not exposed by `gh pr view --json` (gh 2.95.0), so the
+    state has to come from GraphQL -- without that field the sweeper would
+    re-enqueue a PR the queue is already building.
+    """
+
+    def test_reads_state_over_graphql(self):
+        mod = _load_module()
+        payload = json.dumps(
+            {"data": {"repository": {"pullRequest": _pr_state()}}}
+        )
+        with patch.object(mod, "run_gh", return_value=_completed(stdout=payload)) as gh:
+            state = mod.read_pr_state("cuioss/TokenSheriff", 591)
+        assert state == _pr_state()
+        args = gh.call_args[0][0]
+        assert args[:2] == ["api", "graphql"]
+
+    def test_splits_owner_and_repo(self):
+        mod = _load_module()
+        payload = json.dumps({"data": {"repository": {"pullRequest": _pr_state()}}})
+        with patch.object(mod, "run_gh", return_value=_completed(stdout=payload)) as gh:
+            mod.read_pr_state("cuioss/TokenSheriff", 591)
+        args = gh.call_args[0][0]
+        assert "owner=cuioss" in args
+        assert "name=TokenSheriff" in args
+
+    def test_queries_is_in_merge_queue(self):
+        mod = _load_module()
+        assert "isInMergeQueue" in mod.PR_STATE_QUERY
+
+    def test_api_failure_yields_none(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(1, stderr="boom")):
+            assert mod.read_pr_state("cuioss/TokenSheriff", 591) is None
+
+    def test_missing_pull_request_yields_none(self):
+        mod = _load_module()
+        payload = json.dumps({"data": {"repository": {"pullRequest": None}}})
+        with patch.object(mod, "run_gh", return_value=_completed(stdout=payload)):
+            assert mod.read_pr_state("cuioss/TokenSheriff", 591) is None
+
+    def test_malformed_output_yields_none(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(stdout="not json")):
+            assert mod.read_pr_state("cuioss/TokenSheriff", 591) is None
+
+
 class TestSweep:
     """Test the end-to-end sweep over discovered PRs."""
 

--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -1,0 +1,248 @@
+"""Tests for sweep-dependabot-prs.py - the org-central Dependabot merge sweeper."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add parent to path to access conftest
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from conftest import PROJECT_ROOT, run_script
+
+SCRIPT_PATH = PROJECT_ROOT / "workflow-scripts/sweep-dependabot-prs.py"
+
+
+def _load_module():
+    """Load sweep-dependabot-prs.py as a module for unit testing."""
+    spec = importlib.util.spec_from_file_location("sweep_dependabot_prs", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a CompletedProcess as run_gh returns it."""
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _pr_state(**overrides) -> dict:
+    """A ready-to-merge PR state, with overrides for the case under test."""
+    state = {
+        "state": "OPEN",
+        "isDraft": False,
+        "isInMergeQueue": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+    }
+    state.update(overrides)
+    return state
+
+
+class TestArgumentValidation:
+    """Test command line argument handling."""
+
+    def test_rejects_unknown_argument(self):
+        """Should fail on an argument the script does not define."""
+        result = run_script(SCRIPT_PATH, "--not-an-option")
+        assert result.returncode != 0
+
+    def test_help_lists_dry_run(self):
+        """--help should advertise the dry-run mode."""
+        result = run_script(SCRIPT_PATH, "--help")
+        assert result.returncode == 0
+        assert "--dry-run" in result.stdout
+
+
+class TestClassify:
+    """Test the merge-readiness decision."""
+
+    def test_ready_pr_is_merged(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state()) == "merge"
+
+    def test_queued_pr_is_left_alone(self):
+        """A PR already in the queue must not be re-enqueued."""
+        mod = _load_module()
+        assert mod.classify(_pr_state(isInMergeQueue=True)) == "queued"
+
+    def test_draft_is_skipped(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(isDraft=True)) == "draft"
+
+    def test_closed_pr_is_skipped(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(state="CLOSED")) == "not-open"
+
+    def test_conflicting_pr_is_not_ready(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(mergeable="CONFLICTING")) == "not-ready"
+
+    def test_blocked_pr_is_not_ready(self):
+        """BLOCKED means a required check is missing or failing -- never force it."""
+        mod = _load_module()
+        assert mod.classify(_pr_state(mergeStateStatus="BLOCKED")) == "not-ready"
+
+    def test_behind_pr_is_not_ready(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(mergeStateStatus="BEHIND")) == "not-ready"
+
+    def test_unreadable_state_is_unknown(self):
+        mod = _load_module()
+        assert mod.classify(None) == "unknown"
+
+
+class TestFindCandidates:
+    """Test discovery of labelled Dependabot PRs."""
+
+    def test_parses_search_results(self):
+        mod = _load_module()
+        payload = json.dumps(
+            [
+                {
+                    "number": 12,
+                    "repository": {"nameWithOwner": "cuioss/TokenSheriff"},
+                    "url": "https://github.com/cuioss/TokenSheriff/pull/12",
+                    "title": "bump x",
+                }
+            ]
+        )
+        with patch.object(mod, "run_gh", return_value=_completed(stdout=payload)):
+            candidates = mod.find_candidates("cuioss", "automerge", "app/dependabot", 100)
+        assert candidates == [
+            {
+                "repo": "cuioss/TokenSheriff",
+                "number": 12,
+                "url": "https://github.com/cuioss/TokenSheriff/pull/12",
+                "title": "bump x",
+            }
+        ]
+
+    def test_empty_output_yields_no_candidates(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(stdout="")):
+            assert mod.find_candidates("cuioss", "automerge", "app/dependabot", 100) == []
+
+    def test_search_failure_raises(self):
+        """A failed search must not be reported as 'nothing to merge'."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(1, stderr="boom")):
+            try:
+                mod.find_candidates("cuioss", "automerge", "app/dependabot", 100)
+            except RuntimeError as exc:
+                assert "boom" in str(exc)
+            else:
+                raise AssertionError("expected RuntimeError")
+
+    def test_passes_label_and_author_filters(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(stdout="[]")) as gh:
+            mod.find_candidates("cuioss", "automerge", "app/dependabot", 50)
+        args = gh.call_args[0][0]
+        assert args[:3] == ["search", "prs", "--owner"]
+        assert "--label" in args and args[args.index("--label") + 1] == "automerge"
+        assert "--author" in args and args[args.index("--author") + 1] == "app/dependabot"
+        assert "--limit" in args and args[args.index("--limit") + 1] == "50"
+
+
+class TestSweep:
+    """Test the end-to-end sweep over discovered PRs."""
+
+    def _candidate(self):
+        return [
+            {
+                "repo": "cuioss/TokenSheriff",
+                "number": 7,
+                "url": "u",
+                "title": "bump x",
+            }
+        ]
+
+    def test_merges_ready_pr(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "read_pr_state", return_value=_pr_state()),
+            patch.object(mod, "merge_pr", return_value=(True, "queued")) as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        merge.assert_called_once_with("cuioss/TokenSheriff", 7)
+        assert outcomes[0]["action"] == "merged"
+
+    def test_dry_run_does_not_merge(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "read_pr_state", return_value=_pr_state()),
+            patch.object(mod, "merge_pr") as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, True)
+        merge.assert_not_called()
+        assert outcomes[0]["action"] == "would-merge"
+
+    def test_not_ready_pr_is_not_merged(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "read_pr_state", return_value=_pr_state(mergeStateStatus="BLOCKED")),
+            patch.object(mod, "merge_pr") as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        merge.assert_not_called()
+        assert outcomes[0]["action"] == "not-ready"
+
+    def test_merge_failure_is_reported(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "read_pr_state", return_value=_pr_state()),
+            patch.object(mod, "merge_pr", return_value=(False, "not mergeable")),
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        assert outcomes[0]["action"] == "merge-failed"
+        assert outcomes[0]["detail"] == "not mergeable"
+
+
+class TestMergePr:
+    """Test the merge invocation itself."""
+
+    def test_uses_squash_against_the_owning_repo(self):
+        """The queue's merge_method is SQUASH; the direct-merge path must match."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh:
+            ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert ok
+        assert gh.call_args[0][0] == [
+            "pr", "merge", "7", "--repo", "cuioss/TokenSheriff", "--squash",
+        ]
+
+    def test_does_not_pass_auto(self):
+        """--auto is what breaks under the queue; the sweeper merges outright."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh:
+            mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert "--auto" not in gh.call_args[0][0]
+
+
+class TestSummary:
+    """Test reporting."""
+
+    def test_summary_written_to_step_summary(self, tmp_path, monkeypatch):
+        mod = _load_module()
+        summary_file = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        mod.print_summary(
+            [{"repo": "cuioss/x", "number": 1, "url": "u", "title": "t",
+              "action": "merged", "detail": ""}]
+        )
+        assert "cuioss/x#1" in summary_file.read_text()
+
+    def test_empty_sweep_reports_nothing_found(self, tmp_path, monkeypatch):
+        mod = _load_module()
+        summary_file = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        mod.print_summary([])
+        assert "No labelled Dependabot PRs" in summary_file.read_text()

--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -57,6 +57,32 @@ class TestArgumentValidation:
         assert "--dry-run" in result.stdout
 
 
+class TestRunGh:
+    """Test that no single gh call can hang the scheduled sweep."""
+
+    def test_passes_a_timeout(self):
+        mod = _load_module()
+        with patch("subprocess.run", return_value=_completed()) as run:
+            mod.run_gh(["pr", "list"])
+        assert run.call_args.kwargs["timeout"] == mod.GH_CALL_TIMEOUT_SECONDS
+
+    def test_timeout_becomes_a_failed_call(self):
+        """A stalled call must be reported, not raised -- callers handle rc != 0."""
+        mod = _load_module()
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=120),
+        ):
+            result = mod.run_gh(["pr", "list"])
+        assert result.returncode != 0
+        assert "timed out" in result.stderr
+
+    def test_timeout_is_below_the_job_budget(self):
+        """The job is capped at 10 minutes; a single call must not consume it."""
+        mod = _load_module()
+        assert 0 < mod.GH_CALL_TIMEOUT_SECONDS <= 300
+
+
 class TestClassify:
     """Test the merge-readiness decision."""
 

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Merge Dependabot PRs that the auto-merge workflow marked eligible.
+
+reusable-dependabot-auto-merge.yml runs under GITHUB_TOKEN and can only label.
+GitHub does not start workflow runs for events created by GITHUB_TOKEN, so under
+a required merge queue that token cannot land a PR: either its queue entry never
+receives merge_group check runs and is dropped at check_response_timeout_minutes,
+or the auto-merge request never converts into a queue entry at all.
+
+This sweeper runs on a schedule under the cuioss-release-bot App identity, whose
+events do start workflow runs, and performs the merge for every labelled PR that
+GitHub reports as ready. On a merge-queue repo `gh pr merge` enqueues; elsewhere
+it merges directly.
+
+Usage:
+    ./sweep-dependabot-prs.py --dry-run
+    ./sweep-dependabot-prs.py
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+DEFAULT_LABEL = "automerge"
+DEFAULT_OWNER = "cuioss"
+DEFAULT_AUTHOR = "app/dependabot"
+
+# GitHub's own readiness verdict. Anything else means a required check is
+# missing, failing, or the PR is blocked -- never force it.
+READY_MERGE_STATE = "CLEAN"
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a gh CLI command without raising on failure."""
+    return subprocess.run(
+        ["gh"] + args, capture_output=True, text=True, check=False
+    )
+
+
+def write_summary(text: str) -> None:
+    """Append markdown text to the GitHub Actions step summary."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(text + "\n")
+
+
+def find_candidates(owner: str, label: str, author: str, limit: int) -> list[dict]:
+    """Find open, labelled Dependabot PRs across the organization.
+
+    The label is applied only by reusable-dependabot-auto-merge.yml, so its
+    presence is the opt-in signal -- no repository list to keep in sync.
+    """
+    result = run_gh(
+        [
+            "search", "prs",
+            "--owner", owner,
+            "--label", label,
+            "--author", author,
+            "--state", "open",
+            "--limit", str(limit),
+            "--json", "number,repository,url,title",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh search prs failed: {result.stderr.strip()}")
+    if not result.stdout.strip():
+        return []
+    candidates = []
+    for item in json.loads(result.stdout):
+        repo = (item.get("repository") or {}).get("nameWithOwner")
+        if not repo or not item.get("number"):
+            continue
+        candidates.append(
+            {
+                "repo": repo,
+                "number": item["number"],
+                "url": item.get("url", ""),
+                "title": item.get("title", ""),
+            }
+        )
+    return candidates
+
+
+def read_pr_state(repo: str, number: int) -> dict | None:
+    """Read the merge-readiness fields GitHub computes for a PR."""
+    result = run_gh(
+        [
+            "pr", "view", str(number),
+            "--repo", repo,
+            "--json", "isDraft,mergeable,mergeStateStatus,isInMergeQueue,state",
+        ]
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def classify(state: dict | None) -> str:
+    """Decide what to do with a PR from its merge-readiness fields.
+
+    Returns one of: merge, queued, draft, not-open, not-ready, unknown.
+    """
+    if state is None:
+        return "unknown"
+    if state.get("state") != "OPEN":
+        return "not-open"
+    if state.get("isInMergeQueue"):
+        return "queued"
+    if state.get("isDraft"):
+        return "draft"
+    if state.get("mergeable") != "MERGEABLE":
+        return "not-ready"
+    if state.get("mergeStateStatus") != READY_MERGE_STATE:
+        return "not-ready"
+    return "merge"
+
+
+def merge_pr(repo: str, number: int) -> tuple[bool, str]:
+    """Merge (or enqueue) a single PR. Returns (ok, detail)."""
+    result = run_gh(["pr", "merge", str(number), "--repo", repo, "--squash"])
+    if result.returncode == 0:
+        return True, (result.stdout or result.stderr).strip()
+    return False, (result.stderr or result.stdout).strip()
+
+
+def sweep(owner: str, label: str, author: str, limit: int, dry_run: bool) -> list[dict]:
+    """Process every labelled Dependabot PR and report per-PR outcomes."""
+    outcomes = []
+    for pr in find_candidates(owner, label, author, limit):
+        action = classify(read_pr_state(pr["repo"], pr["number"]))
+        outcome = {**pr, "action": action, "detail": ""}
+        if action == "merge":
+            if dry_run:
+                outcome["action"] = "would-merge"
+            else:
+                ok, detail = merge_pr(pr["repo"], pr["number"])
+                outcome["action"] = "merged" if ok else "merge-failed"
+                outcome["detail"] = detail
+        outcomes.append(outcome)
+    return outcomes
+
+
+def print_summary(outcomes: list[dict]) -> None:
+    """Print a per-PR table to stdout and the Actions step summary."""
+    if not outcomes:
+        message = "### Dependabot sweep\n\nNo labelled Dependabot PRs found."
+        print(message)
+        write_summary(message)
+        return
+
+    icons = {
+        "merged": ":white_check_mark: merged/enqueued",
+        "would-merge": ":mag: would merge (dry run)",
+        "merge-failed": ":x: merge failed",
+        "queued": ":hourglass: already in merge queue",
+        "not-ready": ":hourglass: checks not green yet",
+        "draft": ":pencil: draft",
+        "not-open": ":heavy_minus_sign: no longer open",
+        "unknown": ":question: could not read PR state",
+    }
+    lines = [
+        "### Dependabot sweep",
+        "",
+        "| PR | Outcome | Detail |",
+        "|---|---|---|",
+    ]
+    for o in outcomes:
+        pr_link = f"[{o['repo']}#{o['number']}]({o['url']})" if o["url"] else f"{o['repo']}#{o['number']}"
+        lines.append(f"| {pr_link} | {icons.get(o['action'], o['action'])} | {o['detail']} |")
+    summary = "\n".join(lines)
+    print(summary)
+    write_summary(summary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge Dependabot PRs marked eligible for auto-merge"
+    )
+    parser.add_argument("--owner", default=DEFAULT_OWNER, help="GitHub organization")
+    parser.add_argument("--label", default=DEFAULT_LABEL, help="Eligibility label")
+    parser.add_argument("--author", default=DEFAULT_AUTHOR, help="PR author to sweep")
+    parser.add_argument("--limit", type=int, default=100, help="Maximum PRs to inspect")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report what would be merged"
+    )
+    args = parser.parse_args()
+
+    try:
+        outcomes = sweep(args.owner, args.label, args.author, args.limit, args.dry_run)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print_summary(outcomes)
+    return 1 if any(o["action"] == "merge-failed" for o in outcomes) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -85,21 +85,46 @@ def find_candidates(owner: str, label: str, author: str, limit: int) -> list[dic
     return candidates
 
 
+PR_STATE_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      state
+      isDraft
+      mergeable
+      mergeStateStatus
+      isInMergeQueue
+    }
+  }
+}
+"""
+
+
 def read_pr_state(repo: str, number: int) -> dict | None:
-    """Read the merge-readiness fields GitHub computes for a PR."""
+    """Read the merge-readiness fields GitHub computes for a PR.
+
+    Queried over GraphQL rather than `gh pr view --json`: isInMergeQueue is not
+    among the fields that command exposes (checked on gh 2.95.0), and without it
+    the sweeper would re-enqueue a PR the queue is already building.
+    """
+    owner, _, name = repo.partition("/")
     result = run_gh(
         [
-            "pr", "view", str(number),
-            "--repo", repo,
-            "--json", "isDraft,mergeable,mergeStateStatus,isInMergeQueue,state",
+            "api", "graphql",
+            "-f", f"query={PR_STATE_QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"name={name}",
+            "-F", f"number={number}",
         ]
     )
     if result.returncode != 0:
         return None
     try:
-        return json.loads(result.stdout)
+        payload = json.loads(result.stdout)
     except json.JSONDecodeError:
         return None
+    pr = ((payload.get("data") or {}).get("repository") or {}).get("pullRequest")
+    return pr or None
 
 
 def classify(state: dict | None) -> str:

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -31,12 +31,35 @@ DEFAULT_AUTHOR = "app/dependabot"
 # missing, failing, or the PR is blocked -- never force it.
 READY_MERGE_STATE = "CLEAN"
 
+# Upper bound on any single gh call. Well under the job's timeout-minutes so a
+# stalled call surfaces as a reported failure rather than a killed job.
+GH_CALL_TIMEOUT_SECONDS = 120
+
 
 def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run a gh CLI command without raising on failure."""
-    return subprocess.run(
-        ["gh"] + args, capture_output=True, text=True, check=False
-    )
+    """Run a gh CLI command without raising on failure.
+
+    Bounded by GH_CALL_TIMEOUT_SECONDS: the sweeper runs on a 15-minute cron
+    with cancel-in-progress: false, so one hung call (network stall, rate-limit
+    backoff) would otherwise hold the job until the runner default and stack the
+    following scheduled runs behind it. A timeout is reported as a failed call,
+    which every caller already handles.
+    """
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GH_CALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["gh", *args],
+            returncode=124,
+            stdout="",
+            stderr=f"gh call timed out after {GH_CALL_TIMEOUT_SECONDS}s",
+        )
 
 
 def write_summary(text: str) -> None:


### PR DESCRIPTION
## Problem

Dependabot auto-merge has been dead in every merge-queue repo since the queue rolled out on **2026-07-19 ~11:37 CEST**. Across `TokenSheriff`, `nifi-extensions`, `API-Sheriff`, `cui-open-rewrite` and `cuioss-parent-pom`, the last PR merged by `app/github-actions` was **2026-07-17**; everything since was merged by hand. 17 green, mergeable PRs are open right now.

## Root cause

`GITHUB_TOKEN`, not the queue configuration. A Dependabot-triggered workflow only ever holds `GITHUB_TOKEN`, and GitHub starts no workflow runs for events created by that token. Two observed failure shapes, both ending in a green PR that sits open:

| Shape | What happens | Examples |
|---|---|---|
| gh enqueues directly (checks already green) | queue entry never gets its `merge_group` check runs → dropped at `check_response_timeout_minutes` (60 min) → **auto-merge request destroyed** | cui-open-rewrite#121, cuioss-parent-pom#1343 |
| gh enables auto-merge (checks not green yet) | request recorded, never converts into a queue entry | TokenSheriff#578/591/593/594/600, nifi-extensions#464…473, API-Sheriff#101 |

The A/B control is in one repo on one day: `cui-open-rewrite#120`, driven by **cuioss-release-bot**, went `auto_merge_enabled 07:14:40 → added_to_merge_queue 07:15:34 → merged 07:21:08`. `#121`, same workflow under `github-actions[bot]`, was enqueued at 08:23:51, got **zero** merge_group runs, and was removed at 09:27:11.

Also confirmed from the runner log: `! The merge strategy for main is set by the merge queue` — gh discards `--squash` under a queue, which is why every stuck PR records `merge_method: merge`. Cosmetic, not causal.

The 5-minute `min_entries_to_merge_wait_minutes` grace period is **not** involved: human-enqueued PRs merge in ~16 min end to end.

## Change

- **`reusable-dependabot-auto-merge.yml` only labels now.** Policy evaluation stays where the Dependabot metadata is; the merge moves out. Attaching an existing label needs `pull-requests: write`, which every caller already grants — **no consumer workflow changes needed**.
- **`dependabot-sweeper.yml`** (new, here) runs every 15 min, mints a `cuioss-release-bot` token and merges every labelled PR GitHub reports as ready. A scheduled run is not Dependabot-triggered, so it can read `RELEASE_APP_*` — a Dependabot-triggered one cannot — and its events do start `merge_group` runs. Discovery is by label search, so there is no repo list to keep in sync. `--dry-run` available via `workflow_dispatch`.
- **`setup-repo-settings.py`** provisions the `automerge` label, since the labelling workflow cannot create one.
- **`setup-branch-protection.py`** forces `strict_required_status_checks_policy: false` for `merge_queue_repos`. The queue is what brings an entry up to date; requiring it beforehand makes readiness depend on a condition the queue itself satisfies.

Grouped Dependabot updates need no special handling: `fetch-metadata` reports the *highest* semver step across the group, so a group containing one major is excluded by the same condition that excludes a single major.

## Verification

`./pw verify` green — 363 tests (33 new: sweeper readiness classification, discovery, merge invocation, reporting; strict-policy wiring for every queue repo; label provisioning). `check-internal-pinning.py` OK.

## Rollout after merge

1. Release so consumers re-pin the labelling workflow.
2. `setup-repo-settings.py --repo <r> --apply` per repo to create the `automerge` label.
3. `setup-branch-protection.py --repo <r> --apply --required-checks "<current>"` for the 6 queue repos.
4. Manually dispatch the sweeper once with `dry-run` to confirm `RELEASE_APP_*` resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled Dependabot PR sweeping, with optional dry-run reporting.
  * Eligible Dependabot updates are labeled for centralized automated merging.
  * Added automatic repository label provisioning.
  * Improved merge-queue handling for branch protection and pull request readiness.

* **Documentation**
  * Updated workflow and merge-queue guidance, including eligibility rules and configuration options.

* **Tests**
  * Added coverage for Dependabot sweeping, label provisioning, and merge-queue branch protection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->