### PR TITLE
fix(sweeper): verify the merge actually happened, exit 0 is not enough

### DIFF
--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -282,24 +282,90 @@ class TestSweep:
 
 
 class TestMergePr:
-    """Test the merge invocation itself."""
+    """Test the merge invocation and its outcome check.
+
+    `gh pr merge` exits 0 without doing anything when the PR already carries an
+    auto-merge request (observed on nifi-extensions#466), so neither the call
+    nor its exit code can be trusted on its own.
+    """
 
     def test_uses_squash_against_the_owning_repo(self):
         """The queue's merge_method is SQUASH; the direct-merge path must match."""
         mod = _load_module()
-        with patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh:
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh,
+            patch.object(mod, "read_pr_state", return_value=_pr_state(state="MERGED")),
+        ):
             ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
         assert ok
-        assert gh.call_args[0][0] == [
+        assert detail == "merged"
+        assert gh.call_args_list[-1][0][0] == [
             "pr", "merge", "7", "--repo", "cuioss/TokenSheriff", "--squash",
         ]
+
+    def test_clears_auto_merge_before_merging(self):
+        """A pre-existing auto-merge request makes the merge a silent no-op."""
+        mod = _load_module()
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh,
+            patch.object(mod, "read_pr_state", return_value=_pr_state(state="MERGED")),
+        ):
+            mod.merge_pr("cuioss/TokenSheriff", 7)
+        first_call = gh.call_args_list[0][0][0]
+        assert "--disable-auto" in first_call
+        assert "--squash" not in first_call
 
     def test_does_not_pass_auto(self):
         """--auto is what breaks under the queue; the sweeper merges outright."""
         mod = _load_module()
-        with patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh:
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")) as gh,
+            patch.object(mod, "read_pr_state", return_value=_pr_state(state="MERGED")),
+        ):
             mod.merge_pr("cuioss/TokenSheriff", 7)
-        assert "--auto" not in gh.call_args[0][0]
+        assert "--auto" not in gh.call_args_list[-1][0][0]
+
+    def test_enqueued_counts_as_success(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")),
+            patch.object(mod, "read_pr_state", return_value=_pr_state(isInMergeQueue=True)),
+        ):
+            ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert ok
+        assert detail == "enqueued"
+
+    def test_exit_zero_without_movement_is_a_failure(self):
+        """The nifi-extensions#466 case: success reported, nothing happened."""
+        mod = _load_module()
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")),
+            patch.object(mod, "read_pr_state", return_value=_pr_state()),
+        ):
+            ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert ok is False
+        assert "did not move" in detail
+
+    def test_unreadable_state_after_merge_is_a_failure(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(stdout="ok")),
+            patch.object(mod, "read_pr_state", return_value=None),
+        ):
+            ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert ok is False
+        assert "could not be read" in detail
+
+    def test_nonzero_exit_is_a_failure_without_state_read(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "run_gh", return_value=_completed(1, stderr="nope")),
+            patch.object(mod, "read_pr_state") as read,
+        ):
+            ok, detail = mod.merge_pr("cuioss/TokenSheriff", 7)
+        assert ok is False
+        assert detail == "nope"
+        read.assert_not_called()
 
 
 class TestSummary:

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -171,11 +171,35 @@ def classify(state: dict | None) -> str:
 
 
 def merge_pr(repo: str, number: int) -> tuple[bool, str]:
-    """Merge (or enqueue) a single PR. Returns (ok, detail)."""
+    """Merge (or enqueue) a single PR. Returns (ok, detail).
+
+    Two behaviours of `gh pr merge` force the shape of this function:
+
+    - On a PR that already has an auto-merge request, it is a silent no-op that
+      still exits 0. Observed on nifi-extensions#466: the command reported
+      success and the PR was never queued. So any pre-existing auto-merge
+      request is cleared first.
+    - Exit 0 does not mean the PR moved. The outcome is therefore read back from
+      GitHub -- merged, or sitting in the queue -- and only that counts as
+      success. An exit code is necessary but never sufficient.
+    """
+    run_gh(["pr", "merge", str(number), "--repo", repo, "--disable-auto"])
+
     result = run_gh(["pr", "merge", str(number), "--repo", repo, "--squash"])
-    if result.returncode == 0:
-        return True, (result.stdout or result.stderr).strip()
-    return False, (result.stderr or result.stdout).strip()
+    if result.returncode != 0:
+        return False, (result.stderr or result.stdout).strip()
+
+    state = read_pr_state(repo, number)
+    if state is None:
+        return False, "merge reported success but the PR state could not be read"
+    if state.get("state") == "MERGED":
+        return True, "merged"
+    if state.get("isInMergeQueue"):
+        return True, "enqueued"
+    return False, (
+        f"gh exited 0 but the PR did not move "
+        f"(state={state.get('state')} merge={state.get('mergeStateStatus')})"
+    )
 
 
 def sweep(owner: str, label: str, author: str, limit: int, dry_run: bool) -> list[dict]:


### PR DESCRIPTION
## What happened

While recovering `nifi-extensions#466` by hand, my helper reported `ENQUEUED 466`. The queue was empty and the PR had not moved.

Cause: **`gh pr merge --squash` on a PR that already carries an auto-merge request is a silent no-op that still exits 0.** Dependabot had rebased #466, which re-triggered the (old) auto-merge workflow, which re-enabled auto-merge — so the merge command did nothing and said nothing.

The sweeper merged in #215 had exactly the same two holes.

## Why it matters now

During the rollout window — after #215 merged but before consumers re-pin to the new labelling workflow — every consumer still runs the old workflow that calls `gh pr merge --auto`. So a labelled PR carrying a stale auto-merge request is the **common** case, not the rare one. The sweeper would have logged those as merged in its run summary while nothing happened: a green report over a no-op, which is the same failure class this whole epic is about.

## Change

- `merge_pr()` clears any pre-existing auto-merge request before merging.
- It then reads the outcome back from GitHub and counts only `MERGED` or `isInMergeQueue` as success. A no-op now surfaces as `merge-failed` with `gh exited 0 but the PR did not move (state=… merge=…)` in the step summary.
- A non-zero exit still short-circuits without a state read.

## Verification

`./pw verify` green — 383 tests (+5), covering: auto-merge cleared before the merge, enqueue counted as success, merged counted as success, **exit-0-without-movement reported as failure** (the #466 case), unreadable post-merge state reported as failure, and non-zero exit not triggering a state read.

`nifi-extensions#466` itself is now genuinely queued — verified via `isInMergeQueue`, not via an exit code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request merge handling to accurately confirm whether a merge completed or was queued.
  * Existing auto-merge requests are now cleared before attempting a new merge.
  * Added clearer failure reporting when merges do not progress, pull request status cannot be read, or merge commands fail.
  * Prevented incorrect success results when merge commands exit successfully without taking action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->