### PR TITLE
release: prepare 0.16.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.15.5
+  current-version: 0.16.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bumps `release.current-version` so the Release workflow can tag **v0.16.0**.

Ships #215 and #216 — Dependabot auto-merge under the merge queue.

## Why minor, not patch

The contract of `reusable-dependabot-auto-merge.yml` changes: it now applies the `automerge` label and **never merges**. The merge is performed org-centrally by the new `dependabot-sweeper.yml` under a `cuioss-release-bot` App token.

The reason is structural, not stylistic: a Dependabot-triggered workflow only ever holds `GITHUB_TOKEN`, and GitHub starts no workflow runs for events created by that token. Under a required merge queue that makes it incapable of landing a PR — which is why auto-merge has been dead in every queue repo since the queues were created on **2026-07-19**, with 17 green PRs left sitting open.

## Consumers need no edits

Attaching an existing label requires only `pull-requests: write`, which every caller already grants. The release bot's SHA bump is the whole consumer-side change.

## Already in place

- `automerge` label provisioned in all 20 caller repos
- `strict_required_status_checks_policy: false` applied and verified on all six merge-queue repos
- Sweeper dry-run validated against a real labelled PR: discovered it by label search, read its state over GraphQL, and correctly declined it as `checks not green yet`
- All 17 stranded Dependabot PRs recovered and merged

## What goes live on release

Consumers re-pin to v0.16.0, start labelling eligible PRs, and the sweeper merges them within 15 minutes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s release configuration to version 0.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->