### PR TITLE
feat(sweeper): per-repo opt-out, drop the vacuous label input, gate the branch

### DIFF
--- a/.github/actions/read-project-config/schema.json
+++ b/.github/actions/read-project-config/schema.json
@@ -199,6 +199,11 @@
           "type": "boolean",
           "description": "Auto-merge workflow update PRs when CI checks pass",
           "default": true
+        },
+        "dependabot-automerge": {
+          "type": "boolean",
+          "description": "Let the org Dependabot sweeper merge this repo's labelled Dependabot PRs. Set false to opt out.",
+          "default": true
         }
       },
       "additionalProperties": false

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -34,11 +34,6 @@ on:
         type: string
         required: false
         default: 'minor,patch'
-      automerge-label:
-        description: 'Label applied to eligible PRs. The org sweeper merges exactly this label.'
-        type: string
-        required: false
-        default: 'automerge'
 
 permissions:
   contents: read
@@ -83,6 +78,10 @@ jobs:
         # quietly.
         run: gh pr edit "$PR_URL" --add-label "$LABEL"
         env:
-          LABEL: ${{ inputs.automerge-label }}
+          # Not an input: the sweeper searches for this exact literal, and a
+          # per-repo override would silently produce PRs it never finds.
+          # To switch a repo off, set github-automation.dependabot-automerge
+          # to false in its .github/project.yml.
+          LABEL: automerge
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -901,12 +901,47 @@ A Dependabot-triggered workflow also cannot read Actions secrets, so it cannot m
 |string
 |`minor,patch`
 |Comma-separated semver update types to auto-merge (`major`, `minor`, `patch`)
-
-|`automerge-label`
-|string
-|`automerge`
-|Label applied to eligible PRs. The org sweeper merges exactly this label.
 |===
+
+The label name is deliberately *not* an input. The sweeper searches for the
+literal `automerge`, so a per-repo override would produce labelled PRs it never
+finds — labelled, unmerged, and reported as nothing to do.
+
+=== Turning It Off Per Repository
+
+Set the switch in the repo's `.github/project.yml`:
+
+[source,yaml]
+----
+github-automation:
+  dependabot-automerge: false
+----
+
+The sweeper skips the repo and reports it as opted out. Omitting the key means
+participation: the `automerge` label is only ever applied by this workflow, so a
+repo without the caller never produces candidates in the first place.
+
+A `project.yml` that exists but cannot be read or parsed is treated as
+*indeterminate*, not as participation — the sweeper declines to merge and says
+so. A definite absence is an answer; an unreadable config is not.
+
+=== Who Can Be Merged
+
+Two independent gates, both required:
+
+* The labelling job runs only when `github.actor == 'dependabot[bot]'`.
+* The sweeper searches with `--author app/dependabot` and merges only PRs whose
+  head branch starts with `dependabot/`.
+
+The author cannot be forged: `dependabot[bot]` is an App-derived login, GitHub
+usernames admit no brackets, and App slugs are globally unique. The branch check
+is defence in depth — a label survives a force-push, so a collaborator could
+otherwise reuse an already-labelled Dependabot branch for unrelated content.
+
+Note that the update-type policy is enforced only on the labelling path. Anyone
+with write access can hand-apply `automerge` to a Dependabot PR the policy would
+have rejected, and the sweeper will merge it once its required checks are green.
+That is a deliberate manual override, not an oversight.
 
 === No Secrets Required
 

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -917,9 +917,12 @@ github-automation:
   dependabot-automerge: false
 ----
 
-The sweeper skips the repo and reports it as opted out. Omitting the key means
-participation: the `automerge` label is only ever applied by this workflow, so a
-repo without the caller never produces candidates in the first place.
+The sweeper skips the repo and reports it as opted out.
+
+Omitting the key means participation. A repo without the caller workflow is
+never labelled *automatically*, so it normally produces no candidates — but a
+label can also be applied by hand (see below), so absence of the caller is a
+default, not a guarantee. This switch is the only explicit opt-out.
 
 A `project.yml` that exists but cannot be read or parsed is treated as
 *indeterminate*, not as participation — the sweeper declines to merge and says

--- a/docs/project-yml-schema.adoc
+++ b/docs/project-yml-schema.adoc
@@ -146,6 +146,7 @@ NOTE: When Sonar is enabled, the build enforces the SonarCloud Quality Gate. A f
 |Field |Type |Default |Description
 
 |`github-automation.auto-merge-build-versions` |boolean |`true` |Auto-merge workflow update PRs when CI checks pass
+|`github-automation.dependabot-automerge` |boolean |`true` |Let the org Dependabot sweeper merge this repo's labelled Dependabot PRs. Set `false` to opt out.
 |===
 
 ==== Dependency Propagation Section
@@ -234,6 +235,7 @@ pages:
 # GitHub Automation (controls auto-merge of workflow update PRs)
 github-automation:
   auto-merge-build-versions: true
+  dependabot-automerge: true     # false opts this repo out of the Dependabot sweeper
 
 # Consumer repos to receive automatic dependency updates on release
 consumers:

--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -182,6 +182,28 @@ class TestRepoParticipates:
         with patch.object(mod, "run_gh", return_value=_project_yml("a: [unclosed\n")):
             assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
 
+    def test_scalar_document_is_indeterminate(self):
+        """A truthy scalar root would raise out of the sweep, not just misread."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("just a string\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_list_document_is_indeterminate(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("- a\n- b\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_empty_document_is_indeterminate(self):
+        """Empty parses to None -- must not be read as an empty config."""
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_null_document_is_indeterminate(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("null\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
     def test_non_mapping_automation_block_is_indeterminate(self):
         mod = _load_module()
         with patch.object(mod, "run_gh", return_value=_project_yml("github-automation: nope\n")):

--- a/test/workflow/test_sweep_dependabot_prs.py
+++ b/test/workflow/test_sweep_dependabot_prs.py
@@ -37,9 +37,17 @@ def _pr_state(**overrides) -> dict:
         "isInMergeQueue": False,
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
+        "headRefName": "dependabot/maven/some-dep-1.2.3",
     }
     state.update(overrides)
     return state
+
+
+def _project_yml(body: str):
+    """A successful contents API response carrying the given project.yml."""
+    import base64
+
+    return _completed(stdout=base64.b64encode(body.encode()).decode())
 
 
 class TestArgumentValidation:
@@ -119,6 +127,74 @@ class TestClassify:
     def test_unreadable_state_is_unknown(self):
         mod = _load_module()
         assert mod.classify(None) == "unknown"
+
+    def test_non_dependabot_branch_is_rejected(self):
+        """A label survives a force-push; the branch it points at must still
+        be a Dependabot branch."""
+        mod = _load_module()
+        assert mod.classify(_pr_state(headRefName="feature/sneaky")) == "foreign-branch"
+
+    def test_missing_branch_name_is_rejected(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(headRefName=None)) == "foreign-branch"
+
+    def test_branch_prefix_must_be_a_prefix_not_a_substring(self):
+        mod = _load_module()
+        assert mod.classify(_pr_state(headRefName="x/dependabot/npm")) == "foreign-branch"
+
+
+class TestRepoParticipates:
+    """Test the per-repo opt-out switch in .github/project.yml."""
+
+    def test_absent_key_participates(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("name: x\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "yes"
+
+    def test_explicit_true_participates(self):
+        mod = _load_module()
+        body = "github-automation:\n  dependabot-automerge: true\n"
+        with patch.object(mod, "run_gh", return_value=_project_yml(body)):
+            assert mod.repo_participates("cuioss/x", {}) == "yes"
+
+    def test_explicit_false_opts_out(self):
+        mod = _load_module()
+        body = "github-automation:\n  dependabot-automerge: false\n"
+        with patch.object(mod, "run_gh", return_value=_project_yml(body)):
+            assert mod.repo_participates("cuioss/x", {}) == "no"
+
+    def test_missing_file_participates(self):
+        """A definite absence is an answer; the label already gates opt-in."""
+        mod = _load_module()
+        missing = _completed(1, stderr="gh: Not Found (HTTP 404)")
+        with patch.object(mod, "run_gh", return_value=missing):
+            assert mod.repo_participates("cuioss/x", {}) == "yes"
+
+    def test_api_error_is_indeterminate(self):
+        """Unreachable is not the same as absent -- do not merge on a guess."""
+        mod = _load_module()
+        failure = _completed(1, stderr="gh: API rate limit exceeded")
+        with patch.object(mod, "run_gh", return_value=failure):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_malformed_yaml_is_indeterminate(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("a: [unclosed\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_non_mapping_automation_block_is_indeterminate(self):
+        mod = _load_module()
+        with patch.object(mod, "run_gh", return_value=_project_yml("github-automation: nope\n")):
+            assert mod.repo_participates("cuioss/x", {}) == "indeterminate"
+
+    def test_result_is_cached_per_repo(self):
+        """One config read per repo per sweep, not one per PR."""
+        mod = _load_module()
+        cache: dict[str, str] = {}
+        with patch.object(mod, "run_gh", return_value=_project_yml("name: x\n")) as gh:
+            mod.repo_participates("cuioss/x", cache)
+            mod.repo_participates("cuioss/x", cache)
+        assert gh.call_count == 1
 
 
 class TestFindCandidates:
@@ -236,9 +312,47 @@ class TestSweep:
             }
         ]
 
+    def test_opted_out_repo_is_never_read_or_merged(self):
+        """The switch short-circuits before any state read or merge."""
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "repo_participates", return_value="no"),
+            patch.object(mod, "read_pr_state") as read,
+            patch.object(mod, "merge_pr") as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        read.assert_not_called()
+        merge.assert_not_called()
+        assert outcomes[0]["action"] == "opted-out"
+
+    def test_indeterminate_config_does_not_merge(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "repo_participates", return_value="indeterminate"),
+            patch.object(mod, "merge_pr") as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        merge.assert_not_called()
+        assert outcomes[0]["action"] == "config-unreadable"
+
+    def test_foreign_branch_is_not_merged(self):
+        mod = _load_module()
+        with (
+            patch.object(mod, "find_candidates", return_value=self._candidate()),
+            patch.object(mod, "repo_participates", return_value="yes"),
+            patch.object(mod, "read_pr_state", return_value=_pr_state(headRefName="feature/x")),
+            patch.object(mod, "merge_pr") as merge,
+        ):
+            outcomes = mod.sweep("cuioss", "automerge", "app/dependabot", 100, False)
+        merge.assert_not_called()
+        assert outcomes[0]["action"] == "foreign-branch"
+
     def test_merges_ready_pr(self):
         mod = _load_module()
         with (
+            patch.object(mod, "repo_participates", return_value="yes"),
             patch.object(mod, "find_candidates", return_value=self._candidate()),
             patch.object(mod, "read_pr_state", return_value=_pr_state()),
             patch.object(mod, "merge_pr", return_value=(True, "queued")) as merge,
@@ -250,6 +364,7 @@ class TestSweep:
     def test_dry_run_does_not_merge(self):
         mod = _load_module()
         with (
+            patch.object(mod, "repo_participates", return_value="yes"),
             patch.object(mod, "find_candidates", return_value=self._candidate()),
             patch.object(mod, "read_pr_state", return_value=_pr_state()),
             patch.object(mod, "merge_pr") as merge,
@@ -261,6 +376,7 @@ class TestSweep:
     def test_not_ready_pr_is_not_merged(self):
         mod = _load_module()
         with (
+            patch.object(mod, "repo_participates", return_value="yes"),
             patch.object(mod, "find_candidates", return_value=self._candidate()),
             patch.object(mod, "read_pr_state", return_value=_pr_state(mergeStateStatus="BLOCKED")),
             patch.object(mod, "merge_pr") as merge,
@@ -272,6 +388,7 @@ class TestSweep:
     def test_merge_failure_is_reported(self):
         mod = _load_module()
         with (
+            patch.object(mod, "repo_participates", return_value="yes"),
             patch.object(mod, "find_candidates", return_value=self._candidate()),
             patch.object(mod, "read_pr_state", return_value=_pr_state()),
             patch.object(mod, "merge_pr", return_value=(False, "not mergeable")),

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -94,8 +94,10 @@ def write_summary(text: str) -> None:
 def find_candidates(owner: str, label: str, author: str, limit: int) -> list[dict]:
     """Find open, labelled Dependabot PRs across the organization.
 
-    The label is applied only by reusable-dependabot-auto-merge.yml, so its
-    presence is the opt-in signal -- no repository list to keep in sync.
+    The label is normally applied by reusable-dependabot-auto-merge.yml, so its
+    presence is the opt-in signal -- no repository list to keep in sync. It can
+    also be applied by hand as a deliberate override, which is why participation
+    is confirmed per repo by repo_participates() rather than assumed here.
     """
     result = run_gh(
         [
@@ -177,9 +179,10 @@ def repo_participates(repo: str, cache: dict[str, str]) -> str:
     Returns "yes", "no" (opted out), or "indeterminate".
 
     Reads github-automation.dependabot-automerge from the repo's project.yml.
-    Absent file or absent key means yes: participation is already gated by the
-    label, which only the caller workflow applies, so a repo without the caller
-    never produces candidates in the first place.
+    Absent file or absent key means yes. A repo without the caller workflow is
+    never labelled automatically, so it normally produces no candidates -- but a
+    label can also be applied by hand, so that is a default, not an invariant.
+    This switch is what makes an opt-out explicit.
 
     A file that exists but cannot be parsed is "indeterminate", not yes. A
     definite absence is an answer; an unreadable config is not, and guessing
@@ -200,8 +203,15 @@ def repo_participates(repo: str, cache: dict[str, str]) -> str:
 
     try:
         raw = base64.b64decode(result.stdout.strip()).decode("utf-8")
-        config = yaml.safe_load(raw) or {}
+        config = yaml.safe_load(raw)
     except (ValueError, UnicodeDecodeError, yaml.YAMLError):
+        cache[repo] = "indeterminate"
+        return "indeterminate"
+
+    # A scalar or list root parses fine but is not a project.yml. Treating it as
+    # empty would silently participate; calling .get() on it would raise out of
+    # the sweep and take every other repo down with it.
+    if not isinstance(config, dict):
         cache[repo] = "indeterminate"
         return "indeterminate"
 

--- a/workflow-scripts/sweep-dependabot-prs.py
+++ b/workflow-scripts/sweep-dependabot-prs.py
@@ -23,9 +23,29 @@ import os
 import subprocess
 import sys
 
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pre-installed on GitHub runners
+    print("Error: PyYAML not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
 DEFAULT_LABEL = "automerge"
 DEFAULT_OWNER = "cuioss"
 DEFAULT_AUTHOR = "app/dependabot"
+
+# Dependabot always opens from a branch under this prefix. Checked as defence in
+# depth: a label survives a force-push, so a collaborator could otherwise reuse
+# an already-labelled Dependabot branch for unrelated content. The PR author
+# cannot be forged -- dependabot[bot] is an App-derived login and GitHub
+# usernames admit no brackets -- but the branch it points at can be rewritten.
+DEPENDABOT_BRANCH_PREFIX = "dependabot/"
+
+# Per-repo switch in .github/project.yml:
+#   github-automation:
+#     dependabot-automerge: false
+PROJECT_CONFIG_PATH = ".github/project.yml"
+AUTOMATION_KEY = "github-automation"
+OPT_IN_KEY = "dependabot-automerge"
 
 # GitHub's own readiness verdict. Anything else means a required check is
 # missing, failing, or the PR is blocked -- never force it.
@@ -117,6 +137,7 @@ query($owner: String!, $name: String!, $number: Int!) {
       mergeable
       mergeStateStatus
       isInMergeQueue
+      headRefName
     }
   }
 }
@@ -150,15 +171,63 @@ def read_pr_state(repo: str, number: int) -> dict | None:
     return pr or None
 
 
+def repo_participates(repo: str, cache: dict[str, str]) -> str:
+    """Report whether a repo takes part in automated Dependabot merging.
+
+    Returns "yes", "no" (opted out), or "indeterminate".
+
+    Reads github-automation.dependabot-automerge from the repo's project.yml.
+    Absent file or absent key means yes: participation is already gated by the
+    label, which only the caller workflow applies, so a repo without the caller
+    never produces candidates in the first place.
+
+    A file that exists but cannot be parsed is "indeterminate", not yes. A
+    definite absence is an answer; an unreadable config is not, and guessing
+    "participate" there would merge on a repo whose intent is unknown.
+    """
+    if repo in cache:
+        return cache[repo]
+
+    result = run_gh(["api", f"repos/{repo}/contents/{PROJECT_CONFIG_PATH}", "--jq", ".content"])
+    if result.returncode != 0:
+        # Distinguish "no such file" (a definite no-config answer) from any
+        # other API failure (indeterminate).
+        verdict = "yes" if "404" in result.stderr or "Not Found" in result.stderr else "indeterminate"
+        cache[repo] = verdict
+        return verdict
+
+    import base64
+
+    try:
+        raw = base64.b64decode(result.stdout.strip()).decode("utf-8")
+        config = yaml.safe_load(raw) or {}
+    except (ValueError, UnicodeDecodeError, yaml.YAMLError):
+        cache[repo] = "indeterminate"
+        return "indeterminate"
+
+    automation = config.get(AUTOMATION_KEY) or {}
+    if not isinstance(automation, dict):
+        cache[repo] = "indeterminate"
+        return "indeterminate"
+
+    value = automation.get(OPT_IN_KEY, True)
+    cache[repo] = "yes" if value is True else "no"
+    return cache[repo]
+
+
 def classify(state: dict | None) -> str:
     """Decide what to do with a PR from its merge-readiness fields.
 
-    Returns one of: merge, queued, draft, not-open, not-ready, unknown.
+    Returns one of: merge, queued, draft, not-open, not-ready, foreign-branch,
+    unknown.
     """
     if state is None:
         return "unknown"
     if state.get("state") != "OPEN":
         return "not-open"
+    head = state.get("headRefName") or ""
+    if not head.startswith(DEPENDABOT_BRANCH_PREFIX):
+        return "foreign-branch"
     if state.get("isInMergeQueue"):
         return "queued"
     if state.get("isDraft"):
@@ -205,7 +274,17 @@ def merge_pr(repo: str, number: int) -> tuple[bool, str]:
 def sweep(owner: str, label: str, author: str, limit: int, dry_run: bool) -> list[dict]:
     """Process every labelled Dependabot PR and report per-PR outcomes."""
     outcomes = []
+    participation: dict[str, str] = {}
     for pr in find_candidates(owner, label, author, limit):
+        verdict = repo_participates(pr["repo"], participation)
+        if verdict != "yes":
+            outcomes.append({
+                **pr,
+                "action": "opted-out" if verdict == "no" else "config-unreadable",
+                "detail": "",
+            })
+            continue
+
         action = classify(read_pr_state(pr["repo"], pr["number"]))
         outcome = {**pr, "action": action, "detail": ""}
         if action == "merge":
@@ -235,6 +314,9 @@ def print_summary(outcomes: list[dict]) -> None:
         "not-ready": ":hourglass: checks not green yet",
         "draft": ":pencil: draft",
         "not-open": ":heavy_minus_sign: no longer open",
+        "opted-out": ":no_entry_sign: repo opted out (github-automation.dependabot-automerge)",
+        "config-unreadable": ":question: project.yml unreadable - not merging",
+        "foreign-branch": ":warning: labelled PR is not on a dependabot/ branch",
         "unknown": ":question: could not read PR state",
     }
     lines = [


### PR DESCRIPTION
Follow-up to #215/#216, from asking what the sweeper actually guarantees.

## 1. Remove the `automerge-label` input — it did nothing

The caller could set it; the sweeper searched the hard-coded literal `automerge` with nothing wiring the two together. A repo that customised it would have labelled its PRs with a name the sweeper never looks for: PRs sit labelled, the sweep reports "No labelled Dependabot PRs found", no error anywhere. A configuration option that silently does nothing is worse than no option. No repo had set it.

## 2. A real per-repo switch

```yaml
# .github/project.yml
github-automation:
  dependabot-automerge: false
```

- **Absent key or absent file → participate.** The label already gates opt-in: only the caller workflow applies it, so a repo without the caller never produces candidates.
- **Present but unreadable/unparseable → does NOT merge**, reported as `project.yml unreadable`. A definite absence is an answer; an unreadable config is not, and guessing "participate" would merge on a repo whose intent is unknown.
- Cached per repo — one config read per sweep, not one per PR.

Added to `schema.json`, whose `github-automation` block is `additionalProperties: false` and would otherwise have **rejected the key**, breaking config reads in any repo that set it.

## 3. Head branch must start with `dependabot/`

The question that prompted this was whether the actor name is trustworthy. It is:

- `dependabot[bot]` is `type: Bot`, id `49699333`, owned by `github.com/apps/dependabot`.
- No human account can hold that login — GitHub usernames permit only alphanumerics and single hyphens, so brackets are impossible.
- No other App can produce it — the login derives from the globally unique App slug.
- Both gates use it: the labelling job runs only under `github.actor == 'dependabot[bot]'`, and the sweeper searches `--author app/dependabot`.

The residual is elsewhere: **a label survives a force-push**. Someone with write access could force-push unrelated content onto an already-labelled `dependabot/*` branch — the author stays `dependabot[bot]` and the label persists (the labelling job fails closed on the new push, but does not remove the existing label). Requiring the head branch prefix closes the obvious shape of that. It confers no privilege beyond what write access already grants under `required_approving_review_count: 0`, so this is defence in depth, not a patched hole.

## Documented, not hidden

`docs/Workflows.adoc` now states plainly that the update-type policy is enforced **only on the labelling path** — anyone with write access can hand-apply `automerge` to a Dependabot PR the policy would have rejected, and the sweeper will merge it once checks are green. That is a deliberate manual override; it should be written down rather than discovered.

## Verification

`./pw verify` green — 397 tests (+14): opt-out honoured before any state read or merge, absent key/file participates, API error vs 404 distinguished, malformed YAML and non-mapping blocks indeterminate, caching, foreign-branch rejection including the prefix-not-substring case.

Also fixes three pre-existing sweep tests that were exercising the real `repo_participates` and reaching the network.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository-level setting to opt in or out of automated Dependabot pull request merging.
  * Dependabot pull requests are now validated for expected branch origins before merging.
  * Added clearer sweep results for opted-out repositories, unreadable configuration, and unsupported branches.

* **Documentation**
  * Updated workflow and project configuration documentation with the new setting, fixed label behavior, and merge eligibility requirements.

* **Bug Fixes**
  * Prevented incorrectly sourced or ambiguously configured Dependabot pull requests from being merged automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->