### PR TITLE
chore(pr-agent-review): stop asserting a pr-agent-settings value as fixed

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.16.0
+  current-version: 0.16.1
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)

--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -269,11 +269,11 @@ jobs:
       #
       # Gating on the comment instead would be WRONG in both directions, and must stay wrong-proof
       # regardless of how pr-agent-settings is tuned: whether a clean review publishes anything is
-      # controlled there by pr_reviewer.publish_output_no_suggestions (currently true, so that a
-      # reviewer's agreement is observable — see that repo's README § "Why a clean review is
-      # published"), and the review comment is persistent and updated in place, so a stale one from
-      # an earlier run would satisfy a naive check forever. The structured output is the only
-      # oracle that holds under both settings, which is precisely why it is the one used.
+      # controlled there by pr_reviewer.publish_output_no_suggestions (see that repo's README
+      # § "Why a clean review is published"), and the review comment is persistent and updated in
+      # place, so a stale one from an earlier run would satisfy a naive check forever. The
+      # structured output is the only oracle that holds under either setting, which is precisely
+      # why it is the one used.
       #
       # SCOPE — every run that should produce review output, and only those:
       #

--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -267,10 +267,13 @@ jobs:
       # the publish decision — so `steps.review.outputs.review` is written whenever the model
       # produced a review, and is absent whenever every model call failed.
       #
-      # Gating on the comment instead would be WRONG in both directions: a clean review
-      # publishes nothing under pr_reviewer.publish_output_no_suggestions = false (our setting,
-      # to suppress "No major issues detected" noise), and the review comment is persistent and
-      # updated in place, so a stale one from an earlier run would satisfy a naive check.
+      # Gating on the comment instead would be WRONG in both directions, and must stay wrong-proof
+      # regardless of how pr-agent-settings is tuned: whether a clean review publishes anything is
+      # controlled there by pr_reviewer.publish_output_no_suggestions (currently true, so that a
+      # reviewer's agreement is observable — see that repo's README § "Why a clean review is
+      # published"), and the review comment is persistent and updated in place, so a stale one from
+      # an earlier run would satisfy a naive check forever. The structured output is the only
+      # oracle that holds under both settings, which is precisely why it is the one used.
       #
       # SCOPE — every run that should produce review output, and only those:
       #

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1118,8 +1118,10 @@ purpose. There is no automatic re-review on push; request one with a `/review` c
 PR-Agent cannot report its own failure: its action runner catches exceptions and exits `0`, so a
 run whose every model call failed reports success. A fail-closed step therefore verifies the
 reviewer's own structured output (`steps.review.outputs.review`), which is written before the
-publish decision — never a published comment, since a clean review deliberately publishes nothing
-and the comment is persistent and updated in place.
+publish decision — never a published comment. Whether a clean review publishes anything is a
+`pr-agent-settings` tuning decision, not a property of this workflow, and the comment is
+persistent and updated in place, so a stale one would satisfy a naive check forever. The
+structured output is the only oracle that holds however that repository is configured.
 
 The check covers both paths that produce review output: automatic `pull_request` runs, and
 `/review` comments. It is scoped by command rather than by event, because `/ask` and `/help`


### PR DESCRIPTION
Follow-on to cuioss/pr-agent-settings#1, which sets `publish_output_no_suggestions = true` so that a clean review is visible rather than silent.

Two places here asserted the opposite as settled fact — the fail-closed gate's comment in `reusable-pr-agent-review.yml`, and the *Verification* section of `Workflows.adoc`. Both said a clean review "deliberately publishes nothing", naming a value that lives in another repository.

Rather than flip the stated value and invite the same drift on the next tuning change, both now state what is actually invariant: publishing behaviour is a `pr-agent-settings` decision, and **the structured output is the only oracle that holds however that repository is configured**. That is also the real reason the gate keys on it, so the corrected wording explains the design better than the version naming a specific setting did.

No behaviour change — comments and prose only.

## Release

Deliberately **not** released on its own. It rides along with the next reviewer change, so this does not trigger a 21-repo consumer bump wave for a comment fix.

## Verification

`./pw verify workflow` — SUCCESS; workflow YAML re-parsed (7 steps, unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how automated review verification works.
  - Explained why structured review results provide a more reliable success check than persisted comments.
  - Documented handling for reviews with and without suggestions, including stale comments from previous runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->