### PR TITLE
fix(workflows): run the docs-only paths-filter on merge_group

### DIFF
--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -157,11 +157,13 @@ jobs:
         uses: cuioss/cuioss-organization/.github/actions/read-project-config@eceb5a949e5da7c7fe3a98b119e227c80af5f432 # v0.16.1
 
   # Check if only documentation/config files changed (skip build if so).
-  # Skipped on merge_group: paths-filter cannot auto-detect a diff base there,
-  # and a merge-queue run must always build the full merge result anyway.
+  # Runs on merge_group too: paths-filter v4 resolves the diff base from the event
+  # payload (merge_group.base_sha..merge_group.head_sha), so the queue evaluates the
+  # *whole* merge group against its base. A docs-only PR batched with a code PR still
+  # sees code in the diff and still builds; only an entirely non-code merge group skips.
   check-changes:
     needs: config
-    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only && github.event_name != 'merge_group'
+    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -102,11 +102,13 @@ jobs:
         uses: cuioss/cuioss-organization/.github/actions/read-project-config@eceb5a949e5da7c7fe3a98b119e227c80af5f432 # v0.16.1
 
   # Check if only documentation/config files changed (skip tests if so).
-  # Skipped on merge_group: paths-filter cannot auto-detect a diff base there,
-  # and a merge-queue run must always test the full merge result anyway.
+  # Runs on merge_group too: paths-filter v4 resolves the diff base from the event
+  # payload (merge_group.base_sha..merge_group.head_sha), so the queue evaluates the
+  # *whole* merge group against its base. A docs-only PR batched with a code PR still
+  # sees code in the diff and still tests; only an entirely non-code merge group skips.
   check-changes:
     needs: config
-    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only && github.event_name != 'merge_group'
+    if: needs.config.outputs.skip-on-docs-only != 'false' && inputs.skip-on-docs-only
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -98,7 +98,7 @@ new version up immediately via the local path).
 
 The reusable Maven build workflow includes a built-in `check-changes` job using https://github.com/dorny/paths-filter[dorny/paths-filter] that skips build/sonar/deploy jobs when only documentation or config files changed. This is handled entirely inside `reusable-maven-build.yml` — callers do not need any path filtering logic.
 
-**Built-in ignored patterns:** `+**/*.adoc+`, `+**/*.md+`, `doc/**`, `.github/project.yml`, `.github/dependabot.yml`, `LICENSE`, `NOTICE`
+**Built-in ignored patterns:** `+**/*.adoc+`, `+**/*.md+`, `doc/**`, `.plan/**`, `.claude/**`, `.github/project.yml`, `.github/dependabot.yml`, `LICENSE`, `NOTICE`
 
 Repos with additional non-code directories can extend the ignore list via `project.yml`:
 
@@ -109,6 +109,8 @@ maven-build:
   paths-ignore-extra:               # additional patterns to treat as non-code
     - 'e-2-e-playwright/docs/**'
 ----
+
+The filter also runs on `merge_group`. `dorny/paths-filter` v4 resolves the diff range from the merge-queue event payload (`merge_group.base_sha..merge_group.head_sha`), so the queue evaluates the *entire* merge group against its base branch: a docs-only PR batched alongside a code PR still sees code in the diff and still builds, and only a merge group that is entirely non-code skips. Without this, a docs-only PR skipped the build on `pull_request` and then ran the full build and integration-test suite once queued.
 
 This approach is preferred over workflow-level `paths-ignore` because `paths-ignore` prevents the entire workflow from running, which causes required status checks to never report — blocking PR merges. Each reusable workflow includes a `conclusion` gate job that always runs and reports the aggregate result. Branch protection should require only `build / conclusion` (and `integration-tests / conclusion` for IT repos) instead of individual job names like `build / build (21)`.
 


### PR DESCRIPTION
Closes #220.

## Problem

`check-changes` carried `&& github.event_name != 'merge_group'` in both `reusable-maven-build.yml` and `reusable-maven-integration-tests.yml`. A PR touching only ignored paths (`.plan/**`, `.claude/**`, `doc/**`, `**/*.md`, …) therefore skipped build+IT on `pull_request`, and then — because the skipped job yields `should-build == ''`, which is `!= 'false'` — ran the **full** build and integration-test suite once it entered the merge queue.

`cuioss/API-Sheriff` PR #122, a two-line change to `.plan/marshal.json`: ~1 min on `pull_request`, ~18 min of runner time in the queue.

## Fix

Drop the event guard. The stated justification ("paths-filter cannot auto-detect a diff base on `merge_group`") is outdated — `dorny/paths-filter` v4.0.2, the pinned version, handles the event natively in `getChangedFiles()`: it defaults `base` to `merge_group.base_sha` and `ref` to `merge_group.head_sha`, then fetches both SHAs (`git fetch --depth=1`) and does a two-dot diff. No explicit `base:` input is needed, so this is a one-condition change rather than the `${{ ... || '' }}` expression sketched in the issue.

This preserves the correctness property that motivated the skip: the queue evaluates the **whole merge group** against its base branch. A docs-only PR batched alongside a code PR still sees code in the diff and still builds. Only a merge group that is *entirely* non-code skips — precisely the case the filter already sanctions on the PR side.

Downstream guards need no change: `check-changes` now always runs on `merge_group`, so `should-build`/`should-test` is a real `true`/`false` rather than the empty-string fallthrough, and the `conclusion` gate already treats `== 'false'` as a green docs-only skip — branch protection stays satisfied.

## Docs

`docs/Workflows.adoc` — the built-in ignore list was missing `.plan/**` and `.claude/**`; added, plus a paragraph on the merge-queue behaviour.

## Verification

- `./pw verify workflow` — green (316 tests)
- `python3 workflow-scripts/check-internal-pinning.py` — OK
- Both workflows parse; job graph unchanged

The two runtime paths worth watching on the first real landings: an all-non-code merge group must skip build/test with `conclusion` still green, and a mixed merge group must build.