### PR TITLE
release: prepare 0.17.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -3,7 +3,7 @@ description: Reusable GitHub Actions workflows for cuioss organization
 
 # Release configuration (read by release.yml)
 release:
-  current-version: 0.16.1
+  current-version: 0.17.0
   create-github-release: true  # Create GitHub Release with auto-generated notes
 
 # Repositories that consume these workflows (added automatically by /update-github-actions)


### PR DESCRIPTION
Bump version to 0.17.0 for release.

Includes #221 — the docs-only paths-filter now also runs on `merge_group`, so an entirely non-code merge group no longer runs the full build and integration-test suite in the queue.