### PR TITLE
feat(release): guard Maven releases on version-changed, not merged-ness

### DIFF
--- a/.github/actions/release-guard/action.yml
+++ b/.github/actions/release-guard/action.yml
@@ -1,0 +1,64 @@
+name: 'Release Guard'
+description: 'Decides whether a release invocation may proceed: workflow_dispatch always, otherwise only when release.current-version changed and is untagged'
+author: 'cuioss'
+
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  event-name:
+    description: 'Triggering event of the calling workflow'
+    required: false
+    default: ${{ github.event_name }}
+  merge-sha:
+    description: 'Commit to evaluate; defaults to the PR merge commit, falling back to the run sha'
+    required: false
+    default: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+  pull-request-merged:
+    description: 'Whether the triggering pull request was merged'
+    required: false
+    default: ${{ github.event.pull_request.merged }}
+  config-path:
+    description: 'Path to project.yml, relative to the repository root'
+    required: false
+    default: '.github/project.yml'
+
+outputs:
+  proceed:
+    description: '"true" when the release may proceed, "false" when it must be a no-op'
+    value: ${{ steps.guard.outputs.proceed }}
+  reason:
+    description: 'Human-readable explanation of the decision'
+    value: ${{ steps.guard.outputs.reason }}
+  current-version:
+    description: 'release.current-version at the evaluated commit'
+    value: ${{ steps.guard.outputs.current-version }}
+  previous-version:
+    description: 'release.current-version at the first parent (empty if project.yml was absent)'
+    value: ${{ steps.guard.outputs.previous-version }}
+
+runs:
+  using: 'composite'
+  steps:
+    # Values reach the script through the environment, never through shell
+    # interpolation: project.yml is writable by whoever opens the pull request
+    # this guard is judging.
+    - name: Evaluate release guard
+      id: guard
+      shell: bash
+      env:
+        GUARD_ACTION_PATH: ${{ github.action_path }}
+        GUARD_EVENT_NAME: ${{ inputs.event-name }}
+        GUARD_MERGE_SHA: ${{ inputs.merge-sha }}
+        GUARD_PR_MERGED: ${{ inputs.pull-request-merged }}
+        GUARD_CONFIG_PATH: ${{ inputs.config-path }}
+        GUARD_WORKSPACE: ${{ github.workspace }}
+      run: |
+        python3 "$GUARD_ACTION_PATH/release-guard.py" \
+          --event-name "$GUARD_EVENT_NAME" \
+          --merge-sha "$GUARD_MERGE_SHA" \
+          --pull-request-merged "$GUARD_PR_MERGED" \
+          --config-path "$GUARD_CONFIG_PATH" \
+          --repo-dir "$GUARD_WORKSPACE" \
+          --summary-path "$GITHUB_STEP_SUMMARY" >> "$GITHUB_OUTPUT"

--- a/.github/actions/release-guard/action.yml
+++ b/.github/actions/release-guard/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Path to project.yml, relative to the repository root'
     required: false
     default: '.github/project.yml'
+  repo-dir:
+    description: 'Working tree to evaluate; overridden only by the action self-test'
+    required: false
+    default: ${{ github.workspace }}
 
 outputs:
   proceed:
@@ -53,7 +57,7 @@ runs:
         GUARD_MERGE_SHA: ${{ inputs.merge-sha }}
         GUARD_PR_MERGED: ${{ inputs.pull-request-merged }}
         GUARD_CONFIG_PATH: ${{ inputs.config-path }}
-        GUARD_WORKSPACE: ${{ github.workspace }}
+        GUARD_WORKSPACE: ${{ inputs.repo-dir }}
       run: |
         python3 "$GUARD_ACTION_PATH/release-guard.py" \
           --event-name "$GUARD_EVENT_NAME" \

--- a/.github/actions/release-guard/release-guard.py
+++ b/.github/actions/release-guard/release-guard.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Decide whether a Maven release invocation may proceed.
+
+``reusable-maven-release.yml`` is ``on: workflow_call``, so its trigger lives in
+each calling repository and cannot be centralised. The *decision* can be, and
+this is it.
+
+The rule:
+
+* ``workflow_dispatch`` proceeds unconditionally. The deliberate path must stay
+  able to force a release, including re-releasing an unchanged version.
+* Any other event releases only when ``release.current-version`` in
+  ``.github/project.yml`` actually changed on this commit, and no tag for that
+  version exists yet.
+
+Why version-changed rather than merged-ness: ``project.yml`` also carries
+``maven-build``, ``sonar``, ``pages``, ``github-automation``, ``consumers`` and
+``dependency-propagation``. A caller filtering on ``paths: ['.github/project.yml']``
+fires on an ordinary Java-version bump too, and a ``merged == true`` guard does
+not distinguish the two. On 2026-07-12 that published an irrevocable
+``de.cuioss.sheriff.api:*:1.0.0``.
+
+Why the already-tagged refusal is load-bearing rather than belt-and-braces:
+``release:prepare`` never writes ``current-version`` back to ``project.yml`` —
+the field is human-maintained — so a revert or a re-merge of a version-bump PR
+genuinely changes the value between parent and merge commit and would pass the
+version-changed test on its own, at a version already released.
+
+Every failure mode here resolves to "do not release": an unreadable config, an
+unresolvable parent and an unparseable version all exit non-zero, which skips
+the release job and turns the caller's run red. Blocking a release is visible
+and recoverable; publishing to Maven Central is not.
+
+Usage:
+    release-guard.py --event-name pull_request --merge-sha <sha> [--repo-dir .]
+
+Output:
+    key=value lines in GITHUB_OUTPUT format on stdout; diagnostics on stderr.
+
+Exit codes:
+    0 - a decision was reached (see the ``proceed`` output)
+    1 - the decision could not be made; the release must not proceed
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is pre-installed on GitHub runners
+    print("Error: PyYAML not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+# A version is interpolated into shell commands, tag names and GITHUB_OUTPUT
+# further down the release. Anything outside this alphabet is rejected rather
+# than sanitised away, so a malformed value cannot become a silently different
+# release.
+VERSION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+
+class GuardError(Exception):
+    """The decision could not be made. Never means "release anyway"."""
+
+
+# --------------------------------------------------------------------------
+# git access
+# --------------------------------------------------------------------------
+
+
+def _git(repo_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo_dir),
+        capture_output=True,
+        text=True,
+    )
+
+
+def commit_exists(repo_dir: Path, sha: str) -> bool:
+    """True if ``sha`` names a commit object present in the local clone."""
+    return _git(repo_dir, "cat-file", "-e", f"{sha}^{{commit}}").returncode == 0
+
+
+def ensure_commit(repo_dir: Path, sha: str) -> None:
+    """Make ``sha`` available locally, fetching it if the clone is too shallow.
+
+    ``actions/checkout`` defaults to ``fetch-depth: 1``. With depth 1 there is
+    no first parent to compare against, so the guard would read "unchanged"
+    forever — green for the same reason a deleted test is green. The workflow
+    sets the depth explicitly; this is the backstop that turns a mistake there
+    into a loud failure rather than a silent one.
+    """
+    if commit_exists(repo_dir, sha):
+        return
+    _git(repo_dir, "fetch", "--quiet", "origin", sha)
+    if commit_exists(repo_dir, sha):
+        return
+    raise GuardError(
+        f"commit {sha} is not present in the clone and could not be fetched. "
+        "Check out with fetch-depth: 0 — the guard needs history to compare against."
+    )
+
+
+def first_parent(repo_dir: Path, sha: str) -> str:
+    """Return the first parent of ``sha``."""
+    result = _git(repo_dir, "rev-parse", "--verify", "--quiet", f"{sha}^1")
+    parent = result.stdout.strip()
+    if result.returncode != 0 or not parent:
+        raise GuardError(
+            f"commit {sha} has no first parent reachable in this clone. "
+            "Check out with fetch-depth: 0 so the previous version can be read."
+        )
+    return parent
+
+
+def file_at_commit(repo_dir: Path, sha: str, path: str) -> str | None:
+    """Return the contents of ``path`` at ``sha``, or None if it did not exist."""
+    result = _git(repo_dir, "show", f"{sha}:{path}")
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def list_tags(repo_dir: Path) -> list[str]:
+    """Return every tag name in the local clone."""
+    result = _git(repo_dir, "tag", "--list")
+    if result.returncode != 0:
+        raise GuardError("could not list tags; check out with fetch-tags: true")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# decision
+# --------------------------------------------------------------------------
+
+
+def extract_current_version(yaml_text: str | None) -> str | None:
+    """Return ``release.current-version`` from project.yml text, or None.
+
+    Parsed with ``BaseLoader``, which leaves every scalar a string. YAML's
+    normal type resolution reads an unquoted ``1.10`` as the float 1.1, and a
+    guard that compares 1.1 against 1.10 is comparing the wrong things.
+    """
+    if yaml_text is None:
+        return None
+    try:
+        data = yaml.load(yaml_text, Loader=yaml.BaseLoader)  # noqa: S506 - BaseLoader constructs no objects
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    release = data.get("release")
+    if not isinstance(release, dict):
+        return None
+    value = release.get("current-version")
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def is_already_tagged(version: str, tags: list[str]) -> bool:
+    """True if any existing tag plausibly denotes ``version``.
+
+    cuioss repositories tag the bare version (``2.7.0``), but Maven's default
+    ``tagNameFormat`` is ``${artifactId}-${version}`` and ``v``-prefixed tags
+    are common elsewhere. All three forms count. A false positive here blocks a
+    release — visible and recoverable; a false negative republishes.
+    """
+    candidates = {version, f"v{version}"}
+    suffix = f"-{version}"
+    return any(tag in candidates or tag.endswith(suffix) for tag in tags)
+
+
+def decide(
+    event_name: str,
+    pull_request_merged: str,
+    previous_version: str | None,
+    current_version: str,
+    tags: list[str],
+) -> tuple[bool, str]:
+    """Return (proceed, reason) for an invocation.
+
+    ``previous_version`` is None when project.yml did not exist on the parent
+    commit, which counts as a change.
+    """
+    if event_name == "workflow_dispatch":
+        return True, "workflow_dispatch: deliberate release, the guard does not apply"
+
+    if event_name == "pull_request" and pull_request_merged.lower() != "true":
+        return False, "pull request was closed without being merged"
+
+    if previous_version == current_version:
+        return False, f"release.current-version unchanged at {current_version}"
+
+    if is_already_tagged(current_version, tags):
+        return (
+            False,
+            f"release.current-version changed to {current_version}, "
+            f"but a tag for {current_version} already exists",
+        )
+
+    previous_label = previous_version if previous_version is not None else "(absent)"
+    return (
+        True,
+        f"release.current-version changed {previous_label} -> {current_version} and is untagged",
+    )
+
+
+def _validate_version(value: str, where: str) -> str:
+    if not VERSION_PATTERN.match(value):
+        raise GuardError(f"release.current-version at {where} is not a usable version: {value!r}")
+    return value
+
+
+# --------------------------------------------------------------------------
+# entry point
+# --------------------------------------------------------------------------
+
+
+def evaluate(args: argparse.Namespace) -> tuple[bool, str, str, str]:
+    """Return (proceed, reason, current_version, previous_version)."""
+    if args.event_name == "workflow_dispatch":
+        proceed, reason = decide(args.event_name, args.pull_request_merged, None, "", [])
+        return proceed, reason, "", ""
+
+    repo_dir = Path(args.repo_dir).resolve()
+    if not (repo_dir / ".git").exists():
+        raise GuardError(f"{repo_dir} is not a git working tree")
+
+    sha = args.merge_sha.strip()
+    if not SHA_PATTERN.match(sha):
+        raise GuardError(f"merge-sha is not a commit sha: {sha!r}")
+
+    ensure_commit(repo_dir, sha)
+    parent = first_parent(repo_dir, sha)
+
+    current_raw = extract_current_version(file_at_commit(repo_dir, sha, args.config_path))
+    if current_raw is None:
+        raise GuardError(f"could not read release.current-version from {args.config_path} at {sha}")
+    current = _validate_version(current_raw, sha)
+
+    previous_raw = extract_current_version(file_at_commit(repo_dir, parent, args.config_path))
+    previous = _validate_version(previous_raw, parent) if previous_raw is not None else None
+
+    proceed, reason = decide(
+        args.event_name,
+        args.pull_request_merged,
+        previous,
+        current,
+        list_tags(repo_dir),
+    )
+    return proceed, reason, current, previous or ""
+
+
+def _write_summary(proceed: bool, reason: str, summary_path: str | None) -> None:
+    if not summary_path:
+        return
+    verdict = "Release proceeding" if proceed else "Release skipped (no-op)"
+    icon = ":rocket:" if proceed else ":no_entry_sign:"
+    try:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(f"## {icon} {verdict}\n\n{reason}\n\n")
+    except OSError:  # pragma: no cover - the summary is diagnostic, never load-bearing
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Decide whether a Maven release may proceed")
+    parser.add_argument("--event-name", required=True, help="Triggering event of the calling workflow")
+    parser.add_argument("--merge-sha", default="", help="Commit to evaluate")
+    parser.add_argument("--pull-request-merged", default="", help="github.event.pull_request.merged")
+    parser.add_argument("--repo-dir", default=".", help="Working tree of the repository being released")
+    parser.add_argument("--config-path", default=".github/project.yml", help="Path to project.yml")
+    parser.add_argument("--summary-path", default=None, help="File to append a step summary to")
+    args = parser.parse_args()
+
+    try:
+        proceed, reason, current, previous = evaluate(args)
+    except GuardError as error:
+        print(f"::error::Release guard could not decide: {error}", file=sys.stderr)
+        return 1
+
+    verdict = "PROCEED" if proceed else "SKIP"
+    print(f"Release guard: {verdict} — {reason}", file=sys.stderr)
+
+    print(f"proceed={'true' if proceed else 'false'}")
+    print(f"reason={reason}")
+    print(f"current-version={current}")
+    print(f"previous-version={previous}")
+
+    _write_summary(proceed, reason, args.summary_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/release-guard/release-guard.py
+++ b/.github/actions/release-guard/release-guard.py
@@ -119,10 +119,22 @@ def first_parent(repo_dir: Path, sha: str) -> str:
 
 
 def file_at_commit(repo_dir: Path, sha: str, path: str) -> str | None:
-    """Return the contents of ``path`` at ``sha``, or None if it did not exist."""
+    """Return the contents of ``path`` at ``sha``, or None if it did not exist.
+
+    Absence and unreadability are deliberately kept apart. Absence is a real
+    state with a defined meaning (the config was introduced on this commit);
+    "git could not read a file that is in the tree" is not, and collapsing the
+    two would let a read failure be reported as a version change.
+    """
+    listing = _git(repo_dir, "ls-tree", "--name-only", sha, "--", path)
+    if listing.returncode != 0:
+        raise GuardError(f"could not read the tree at {sha}")
+    if not listing.stdout.strip():
+        return None
+
     result = _git(repo_dir, "show", f"{sha}:{path}")
     if result.returncode != 0:
-        return None
+        raise GuardError(f"{path} is present at {sha} but could not be read")
     return result.stdout
 
 
@@ -139,28 +151,33 @@ def list_tags(repo_dir: Path) -> list[str]:
 # --------------------------------------------------------------------------
 
 
-def extract_current_version(yaml_text: str | None) -> str | None:
-    """Return ``release.current-version`` from project.yml text, or None.
+def extract_current_version(yaml_text: str, where: str) -> str:
+    """Return ``release.current-version`` from project.yml text.
+
+    Raises rather than returning a sentinel. A malformed config is not the same
+    thing as a config that does not exist: the absent case has a defined
+    meaning (the version was introduced here, so it counts as changed), while
+    "unparseable" means the comparison cannot be made at all. Returning None
+    for both would let a broken parent config read as a version change and
+    release.
 
     Parsed with ``BaseLoader``, which leaves every scalar a string. YAML's
     normal type resolution reads an unquoted ``1.10`` as the float 1.1, and a
-    guard that compares 1.1 against 1.10 is comparing the wrong things.
+    guard comparing 1.1 against 1.10 is comparing the wrong things.
     """
-    if yaml_text is None:
-        return None
     try:
         data = yaml.load(yaml_text, Loader=yaml.BaseLoader)  # noqa: S506 - BaseLoader constructs no objects
-    except yaml.YAMLError:
-        return None
+    except yaml.YAMLError as error:
+        raise GuardError(f"project.yml at {where} is not valid YAML: {error}") from error
     if not isinstance(data, dict):
-        return None
+        raise GuardError(f"project.yml at {where} is not a mapping")
     release = data.get("release")
     if not isinstance(release, dict):
-        return None
+        raise GuardError(f"project.yml at {where} has no release block")
     value = release.get("current-version")
-    if not isinstance(value, str):
-        return None
-    return value.strip() or None
+    if not isinstance(value, str) or not value.strip():
+        raise GuardError(f"project.yml at {where} has no release.current-version")
+    return value.strip()
 
 
 def is_already_tagged(version: str, tags: list[str]) -> bool:
@@ -239,13 +256,20 @@ def evaluate(args: argparse.Namespace) -> tuple[bool, str, str, str]:
     ensure_commit(repo_dir, sha)
     parent = first_parent(repo_dir, sha)
 
-    current_raw = extract_current_version(file_at_commit(repo_dir, sha, args.config_path))
-    if current_raw is None:
-        raise GuardError(f"could not read release.current-version from {args.config_path} at {sha}")
-    current = _validate_version(current_raw, sha)
+    current_text = file_at_commit(repo_dir, sha, args.config_path)
+    if current_text is None:
+        raise GuardError(f"{args.config_path} does not exist at {sha}")
+    current = _validate_version(extract_current_version(current_text, sha), sha)
 
-    previous_raw = extract_current_version(file_at_commit(repo_dir, parent, args.config_path))
-    previous = _validate_version(previous_raw, parent) if previous_raw is not None else None
+    # An absent parent config is the one None that means something: the config
+    # was introduced on this commit, which counts as a change. Anything else
+    # about the parent that cannot be read has already raised by now.
+    previous_text = file_at_commit(repo_dir, parent, args.config_path)
+    previous = (
+        None
+        if previous_text is None
+        else _validate_version(extract_current_version(previous_text, parent), parent)
+    )
 
     proceed, reason = decide(
         args.event_name,

--- a/.github/workflows/action-self-test.yml
+++ b/.github/workflows/action-self-test.yml
@@ -105,3 +105,140 @@ jobs:
           check "absent-config cache-dependency-glob is empty" "$DEFAULT_CACHE_GLOB" ""
 
           exit $fail
+
+  # The release guard decides whether a Maven Central publish happens. Unit tests
+  # cover the script; this covers the action — that its declared outputs actually
+  # materialize for the consuming `if:` in reusable-maven-release.yml.
+  #
+  # Both controls run here, and the pair is the point. A guard permanently stuck
+  # on "unchanged" — the fetch-depth: 1 failure — passes the negative control
+  # identically to a working one: green because its subject was effectively
+  # deleted. Only the matched positive control tells them apart.
+  release-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # A real repository with real history, not a fixture file: the guard's job
+      # is reading git, and a stub proves nothing about that.
+      - name: Build a synthetic release history
+        id: fixture
+        run: |
+          set -euo pipefail
+          REPO="$RUNNER_TEMP/guard-fixture"
+          rm -rf "$REPO"
+          mkdir -p "$REPO/.github"
+          cd "$REPO"
+          git init --quiet --initial-branch main
+          git config user.email "self-test@example.com"
+          git config user.name "self-test"
+
+          commit() {  # commit <version> <java-versions> <message>
+            printf 'release:\n  current-version: %s\nmaven-build:\n  java-versions: %s\n' "$1" "$2" \
+              > .github/project.yml
+            git add -A
+            git commit --quiet -m "$3"
+          }
+
+          commit 1.0.0 '["21"]' "release 1.0.0"
+          git tag 1.0.0
+
+          commit 1.1.0 '["21"]' "release: prepare 1.1.0"
+          echo "changed-untagged=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git tag 1.1.0
+
+          commit 1.1.0 '["21","25"]' "chore: add java 25 to the build matrix"
+          echo "unchanged=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          # A revert genuinely changes current-version between parent and merge
+          # commit, at a version already released.
+          commit 1.0.0 '["21","25"]' "revert the 1.1.0 bump"
+          echo "changed-tagged=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          echo "repo-dir=$REPO" >> "$GITHUB_OUTPUT"
+
+      # Negative control: a config-only edit must not release.
+      - name: Guard on an unchanged version
+        id: unchanged
+        uses: ./.github/actions/release-guard
+        with:
+          event-name: pull_request
+          pull-request-merged: 'true'
+          merge-sha: ${{ steps.fixture.outputs.unchanged }}
+          repo-dir: ${{ steps.fixture.outputs.repo-dir }}
+
+      # Matched positive control: a version bump must still release.
+      - name: Guard on a changed, untagged version
+        id: changed
+        uses: ./.github/actions/release-guard
+        with:
+          event-name: pull_request
+          pull-request-merged: 'true'
+          merge-sha: ${{ steps.fixture.outputs.changed-untagged }}
+          repo-dir: ${{ steps.fixture.outputs.repo-dir }}
+
+      - name: Guard on a changed but already-tagged version
+        id: tagged
+        uses: ./.github/actions/release-guard
+        with:
+          event-name: pull_request
+          pull-request-merged: 'true'
+          merge-sha: ${{ steps.fixture.outputs.changed-tagged }}
+          repo-dir: ${{ steps.fixture.outputs.repo-dir }}
+
+      - name: Guard on an unmerged pull request
+        id: unmerged
+        uses: ./.github/actions/release-guard
+        with:
+          event-name: pull_request
+          pull-request-merged: 'false'
+          merge-sha: ${{ steps.fixture.outputs.changed-untagged }}
+          repo-dir: ${{ steps.fixture.outputs.repo-dir }}
+
+      # The deliberate path must never be blocked, and must not need a checkout.
+      - name: Guard on workflow_dispatch
+        id: dispatch
+        uses: ./.github/actions/release-guard
+        with:
+          event-name: workflow_dispatch
+          repo-dir: ${{ runner.temp }}/does-not-exist
+
+      - name: Assert both controls
+        env:
+          UNCHANGED: ${{ steps.unchanged.outputs.proceed }}
+          CHANGED: ${{ steps.changed.outputs.proceed }}
+          TAGGED: ${{ steps.tagged.outputs.proceed }}
+          UNMERGED: ${{ steps.unmerged.outputs.proceed }}
+          DISPATCH: ${{ steps.dispatch.outputs.proceed }}
+          CHANGED_VERSION: ${{ steps.changed.outputs.current-version }}
+        run: |
+          fail=0
+          check() {
+            local label="$1" actual="$2" expected="$3"
+            if [[ "$actual" != "$expected" ]]; then
+              echo "::error::$label — expected '$expected', got '$actual'"
+              fail=1
+            else
+              echo "ok: $label = '$actual'"
+            fi
+          }
+
+          check "unchanged version skips" "$UNCHANGED" "false"
+          check "changed untagged version releases" "$CHANGED" "true"
+          check "changed but tagged version skips" "$TAGGED" "false"
+          check "unmerged pull request skips" "$UNMERGED" "false"
+          check "workflow_dispatch always releases" "$DISPATCH" "true"
+
+          # An empty output here would satisfy the `!= 'true'` half of the guard
+          # by accident, so assert the value the release job would consume.
+          check "changed version output materializes" "$CHANGED_VERSION" "1.1.0"
+
+          exit $fail

--- a/.github/workflows/action-self-test.yml
+++ b/.github/workflows/action-self-test.yml
@@ -151,9 +151,12 @@ jobs:
           commit 1.0.0 '["21"]' "release 1.0.0"
           git tag 1.0.0
 
+          # 1.1.0 is deliberately never tagged. Tagging it here would make the
+          # positive control fail through the already-tagged branch instead of
+          # succeeding — which is how this fixture was first written, and what
+          # the positive control caught.
           commit 1.1.0 '["21"]' "release: prepare 1.1.0"
           echo "changed-untagged=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          git tag 1.1.0
 
           commit 1.1.0 '["21","25"]' "chore: add java 25 to the build matrix"
           echo "unchanged=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -37,7 +37,46 @@ permissions:
   contents: read
 
 jobs:
+  # A pull_request-triggered invocation is a no-op unless release.current-version
+  # actually changed on this merge — and a refusal even then if that version is
+  # already tagged. workflow_dispatch proceeds unconditionally.
+  #
+  # This lives in the reusable workflow rather than in an opt-in action on
+  # purpose: callers pin this workflow by SHA, so the guard reaches every caller
+  # on a mechanical pin bump, while an opt-in action needs per-repo wiring — N
+  # chances to get it wrong on a mechanism whose failure mode is an irrevocable
+  # publish. See "Release Guard" in docs/Workflows.adoc.
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      proceed: ${{ steps.guard.outputs.proceed }}
+      reason: ${{ steps.guard.outputs.reason }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # fetch-depth: 0 and fetch-tags are load-bearing, not tidiness. At the
+      # default depth of 1 there is no first parent to compare against and no
+      # tags to check, so the guard would read "unchanged" forever — green
+      # because its subject was effectively deleted.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Evaluate release guard
+        id: guard
+        uses: cuioss/cuioss-organization/.github/actions/release-guard@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+
   release:
+    needs: [guard]
+    if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Centralized workflows called by individual cuioss repositories:
 | Workflow | Purpose |
 |----------|---------|
 | `reusable-maven-build.yml` | Multi-version Java build, Sonar analysis, snapshot deploy |
-| `reusable-maven-release.yml` | Release to Maven Central with GPG signing |
+| `reusable-maven-release.yml` | Release to Maven Central with GPG signing. Its `guard` job makes a non-`workflow_dispatch` invocation a no-op unless `release.current-version` changed on this merge and is untagged — the trigger must stay per-caller (`on:` is evaluated only in the calling repo), the decision is central. See "Release Guard" in `docs/Workflows.adoc` |
 | `reusable-maven-integration-tests.yml` | Integration/E2E tests with optional report deployment |
 | `reusable-scorecards.yml` | OpenSSF Scorecard security analysis |
 | `reusable-dependency-review.yml` | Dependency vulnerability scanning on PRs |

--- a/build.py
+++ b/build.py
@@ -21,6 +21,7 @@ from pathlib import Path
 MODULES = {
     "workflow": [
         ".github/actions/read-project-config/read-config.py",
+        ".github/actions/release-guard/release-guard.py",
         ".github/actions/assemble-test-reports/assemble-reports.py",
         ".github/actions/assemble-test-reports/generate-overview-index.py",
         "workflow-scripts/update-workflow-references.py",
@@ -41,6 +42,7 @@ MODULES = {
 # All source paths for full compilation
 ALL_SOURCES = [
     ".github/actions/read-project-config/read-config.py",
+    ".github/actions/release-guard/release-guard.py",
     ".github/actions/assemble-test-reports/assemble-reports.py",
     ".github/actions/assemble-test-reports/generate-overview-index.py",
     "workflow-scripts/update-workflow-references.py",

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -376,9 +376,30 @@ Anything the guard cannot decide — an unreadable `project.yml`, an unresolvabl
 a version string that is not a usable version — fails the job. Blocking a release is visible
 and recoverable; publishing to Maven Central is not.
 
-When the guard skips, the `release` job and everything downstream of it are skipped, so a
-caller reading `needs.release.outputs.*` sees empty strings. Guard a caller-side job that
-consumes those outputs with `if: needs.release.result == 'success'`.
+==== What a caller sees when the guard skips
+
+The `release` job and everything downstream of it are skipped, so the workflow's outputs are
+empty strings.
+
+The calling job's `result` is **not** a usable signal for this. The guard job itself ran and
+succeeded, so the called workflow's run has one successful job and several skipped ones —
+which GitHub reports as `success`. A caller-side job written as
+
+[source,yaml]
+----
+if: needs.release.result == 'success'   # WRONG — true even when nothing was released
+----
+
+runs anyway, with every output empty. Test the output instead:
+
+[source,yaml]
+----
+if: needs.release.outputs.released-version != ''
+----
+
+Here `needs.release` is the *caller's own* job — the one whose `uses:` points at this
+workflow — not the `release` job inside it; caller jobs cannot reach a called workflow's
+internal jobs at all.
 
 NOTE: The guard checks out with `fetch-depth: 0` and `fetch-tags: true`. Both are
 load-bearing: at `actions/checkout`'s default depth of 1 there is no first parent to compare

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -336,6 +336,55 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 ----
 
+=== Release Guard
+
+The trigger above fires on **any** merged edit to `.github/project.yml`. That file also
+carries `maven-build`, `sonar`, `pages`, `github-automation`, `consumers` and
+`dependency-propagation`, so an ordinary Java-version bump matches the `paths:` filter too,
+and `if: github.event.pull_request.merged == true` does not tell the two apart. On
+2026-07-12 exactly that shape published an irrevocable `de.cuioss.sheriff.api:*:1.0.0`.
+
+`reusable-maven-release.yml` therefore runs a `guard` job before anything else. The trigger
+has to stay in each caller — GitHub evaluates an `on:` block only in the calling repository —
+but the decision is central, so every caller gets it on a pin bump and none has to wire
+anything up.
+
+[cols="1,2"]
+|===
+|Invocation |Outcome
+
+|`workflow_dispatch`
+|Proceeds unconditionally, including a re-release of an unchanged version. The deliberate
+path is never blocked.
+
+|Merged PR, `release.current-version` unchanged
+|**Skipped.** A no-op, not a failure — the caller's run stays green.
+
+|Merged PR, version changed, tag already exists
+|**Skipped.** `release:prepare` never writes `current-version` back to `project.yml`, so a
+revert or a re-merge of a version-bump PR genuinely changes the value and would otherwise
+release an already-published version a second time.
+
+|Merged PR, version changed, untagged
+|Proceeds.
+
+|PR closed without merging
+|**Skipped**, regardless of the version.
+|===
+
+Anything the guard cannot decide — an unreadable `project.yml`, an unresolvable first parent,
+a version string that is not a usable version — fails the job. Blocking a release is visible
+and recoverable; publishing to Maven Central is not.
+
+When the guard skips, the `release` job and everything downstream of it are skipped, so a
+caller reading `needs.release.outputs.*` sees empty strings. Guard a caller-side job that
+consumes those outputs with `if: needs.release.result == 'success'`.
+
+NOTE: The guard checks out with `fetch-depth: 0` and `fetch-tags: true`. Both are
+load-bearing: at `actions/checkout`'s default depth of 1 there is no first parent to compare
+against and no tags to check, and the guard would read "unchanged" forever — green for the
+same reason a deleted test is green.
+
 === Inputs (Optional - override project.yml)
 
 [cols="1,1,1,2"]

--- a/docs/workflow-examples/maven-release-caller.yml
+++ b/docs/workflow-examples/maven-release-caller.yml
@@ -1,5 +1,11 @@
 # Example: Copy this to your repo as .github/workflows/release.yml
 # Configuration is read from .github/project.yml - no inputs needed!
+#
+# The pull_request trigger below fires on ANY merged edit to project.yml, which
+# also carries maven-build, sonar, pages and more. The reusable workflow's own
+# guard job is what narrows that to an actual release: it is a no-op unless
+# release.current-version changed on the merge and is not already tagged.
+# See "Release Guard" in docs/Workflows.adoc.
 name: Release
 
 on:

--- a/test/workflow/test_release_guard.py
+++ b/test/workflow/test_release_guard.py
@@ -1,0 +1,310 @@
+"""Tests for release-guard.py - the version-changed release guard.
+
+These build real git repositories rather than mocking git. The guard's whole
+job is to read history correctly, and the failure mode it exists to prevent
+(a clone too shallow to have a first parent) is invisible to a mock.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from conftest import PROJECT_ROOT, run_script
+
+SCRIPT_PATH = PROJECT_ROOT / ".github/actions/release-guard/release-guard.py"
+
+PROJECT_YML = """\
+name: demo
+release:
+  current-version: {version}
+  next-version: 9.9.9-SNAPSHOT
+maven-build:
+  java-versions: {java_versions}
+sonar:
+  enabled: true
+"""
+
+
+def _parse_output(stdout: str) -> dict[str, str]:
+    """Parse GITHUB_OUTPUT-style key=value lines into a dict."""
+    return {
+        line.split("=", 1)[0]: line.split("=", 1)[1]
+        for line in stdout.strip().split("\n")
+        if "=" in line
+    }
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+class Repo:
+    """A throwaway git repository with a project.yml commit helper."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        path.mkdir(parents=True, exist_ok=True)
+        _git(path, "init", "--quiet", "--initial-branch", "main")
+        _git(path, "config", "user.email", "test@example.com")
+        _git(path, "config", "user.name", "test")
+        (path / ".github").mkdir()
+
+    def commit(self, version: str, java_versions: str = '["21"]', message: str = "change") -> str:
+        (self.path / ".github/project.yml").write_text(
+            PROJECT_YML.format(version=version, java_versions=java_versions)
+        )
+        _git(self.path, "add", "-A")
+        _git(self.path, "commit", "--quiet", "-m", message)
+        return _git(self.path, "rev-parse", "HEAD")
+
+    def commit_without_config(self, message: str = "no config") -> str:
+        (self.path / "README.md").write_text(message)
+        _git(self.path, "add", "-A")
+        _git(self.path, "commit", "--quiet", "-m", message)
+        return _git(self.path, "rev-parse", "HEAD")
+
+    def tag(self, name: str) -> None:
+        _git(self.path, "tag", name)
+
+
+@pytest.fixture
+def repo(tmp_path) -> Repo:
+    return Repo(tmp_path / "repo")
+
+
+def run_guard(repo: Repo, sha: str, event_name: str = "pull_request", merged: str = "true", **kwargs):
+    args = [
+        "--event-name",
+        event_name,
+        "--merge-sha",
+        sha,
+        "--pull-request-merged",
+        merged,
+        "--repo-dir",
+        str(repo.path),
+    ]
+    for key, value in kwargs.items():
+        args += [f"--{key.replace('_', '-')}", value]
+    return run_script(SCRIPT_PATH, *args)
+
+
+class TestWorkflowDispatch:
+    """The deliberate path must never be blocked."""
+
+    def test_dispatch_proceeds_on_unchanged_version(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("1.0.0", java_versions='["21","25"]')
+        result = run_guard(repo, sha, event_name="workflow_dispatch")
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["proceed"] == "true"
+
+    def test_dispatch_proceeds_on_already_tagged_version(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        repo.tag("2.0.0")
+        result = run_guard(repo, sha, event_name="workflow_dispatch")
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["proceed"] == "true"
+
+    def test_dispatch_needs_no_repository(self, tmp_path):
+        """Dispatch short-circuits before touching git at all."""
+        result = run_script(
+            SCRIPT_PATH,
+            "--event-name",
+            "workflow_dispatch",
+            "--repo-dir",
+            str(tmp_path / "does-not-exist"),
+        )
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["proceed"] == "true"
+
+
+class TestNegativeControl:
+    """A non-release project.yml edit must not release."""
+
+    def test_unchanged_version_skips(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("1.0.0", java_versions='["21","25"]', message="bump java versions")
+        result = run_guard(repo, sha)
+        assert result.returncode == 0
+        output = _parse_output(result.stdout)
+        assert output["proceed"] == "false"
+        assert "unchanged" in output["reason"]
+
+    def test_unchanged_version_exits_success(self, repo):
+        """A skip is a no-op, not a failure — the caller's run stays green."""
+        repo.commit("1.0.0")
+        sha = repo.commit("1.0.0", java_versions='["25"]')
+        assert run_guard(repo, sha).returncode == 0
+
+
+class TestPositiveControl:
+    """The matched control: a version change must actually fire."""
+
+    def test_changed_untagged_version_proceeds(self, repo):
+        repo.commit("1.0.0")
+        repo.tag("1.0.0")
+        sha = repo.commit("1.1.0", message="release: prepare 1.1.0")
+        result = run_guard(repo, sha)
+        assert result.returncode == 0
+        output = _parse_output(result.stdout)
+        assert output["proceed"] == "true"
+        assert output["current-version"] == "1.1.0"
+        assert output["previous-version"] == "1.0.0"
+
+    def test_config_absent_on_parent_counts_as_changed(self, repo):
+        repo.commit_without_config()
+        sha = repo.commit("0.1.0")
+        result = run_guard(repo, sha)
+        output = _parse_output(result.stdout)
+        assert output["proceed"] == "true"
+        assert output["previous-version"] == ""
+
+
+class TestAlreadyTagged:
+    """A revert or re-merge changes the value at a version already released."""
+
+    def test_changed_but_tagged_skips(self, repo):
+        repo.commit("1.0.0")
+        repo.tag("1.0.0")
+        repo.commit("1.1.0")
+        repo.tag("1.1.0")
+        # A revert of the 1.1.0 bump: the value genuinely changes 1.1.0 -> 1.0.0.
+        sha = repo.commit("1.0.0", message="revert version bump")
+        result = run_guard(repo, sha)
+        output = _parse_output(result.stdout)
+        assert output["proceed"] == "false"
+        assert "already exists" in output["reason"]
+
+    def test_v_prefixed_tag_counts(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        repo.tag("v2.0.0")
+        assert _parse_output(run_guard(repo, sha).stdout)["proceed"] == "false"
+
+    def test_maven_default_tag_name_format_counts(self, repo):
+        """Maven's default tagNameFormat is ${artifactId}-${version}."""
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        repo.tag("demo-artifact-2.0.0")
+        assert _parse_output(run_guard(repo, sha).stdout)["proceed"] == "false"
+
+    def test_unrelated_tag_does_not_block(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        repo.tag("1.9.0")
+        repo.tag("v1.0.0")
+        assert _parse_output(run_guard(repo, sha).stdout)["proceed"] == "true"
+
+    def test_tag_prefix_alone_does_not_block(self, repo):
+        """'2.0.0' must not be considered tagged by the existence of '2.0.0-rc1'."""
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        repo.tag("2.0.0-rc1")
+        assert _parse_output(run_guard(repo, sha).stdout)["proceed"] == "true"
+
+
+class TestUnmergedPullRequest:
+    """A closed-but-unmerged PR must never release, even if it bumps the version."""
+
+    def test_unmerged_pull_request_skips(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        result = run_guard(repo, sha, merged="false")
+        output = _parse_output(result.stdout)
+        assert output["proceed"] == "false"
+        assert "without being merged" in output["reason"]
+
+    def test_non_pull_request_event_is_unaffected_by_merged_flag(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit("2.0.0")
+        result = run_guard(repo, sha, event_name="push", merged="")
+        assert _parse_output(result.stdout)["proceed"] == "true"
+
+
+class TestFailsClosed:
+    """Every undecidable case must refuse loudly rather than release quietly."""
+
+    def test_shallow_clone_is_an_error_not_a_skip(self, repo, tmp_path):
+        """The fetch-depth: 1 trap: a stuck guard must be loud, not green."""
+        repo.commit("1.0.0")
+        repo.commit("2.0.0")
+        shallow = tmp_path / "shallow"
+        subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", f"file://{repo.path}", str(shallow)],
+            check=True,
+            capture_output=True,
+        )
+        sha = _git(shallow, "rev-parse", "HEAD")
+        result = run_script(
+            SCRIPT_PATH,
+            "--event-name",
+            "pull_request",
+            "--merge-sha",
+            sha,
+            "--pull-request-merged",
+            "true",
+            "--repo-dir",
+            str(shallow),
+        )
+        assert result.returncode == 1
+        assert "fetch-depth: 0" in result.stderr
+
+    def test_missing_config_at_merge_commit_is_an_error(self, repo):
+        repo.commit("1.0.0")
+        _git(repo.path, "rm", "--quiet", ".github/project.yml")
+        _git(repo.path, "commit", "--quiet", "-m", "remove config")
+        sha = _git(repo.path, "rev-parse", "HEAD")
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "current-version" in result.stderr
+
+    def test_unknown_commit_is_an_error(self, repo):
+        repo.commit("1.0.0")
+        result = run_guard(repo, "0" * 40)
+        assert result.returncode == 1
+
+    def test_non_sha_merge_sha_is_an_error(self, repo):
+        repo.commit("1.0.0")
+        result = run_guard(repo, "refs/heads/main")
+        assert result.returncode == 1
+
+    def test_initial_commit_has_no_parent_and_errors(self, repo):
+        sha = repo.commit("1.0.0")
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "first parent" in result.stderr
+
+    def test_hostile_version_value_is_rejected(self, repo):
+        repo.commit("1.0.0")
+        sha = repo.commit('"1.0.0; rm -rf /"')
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "not a usable version" in result.stderr
+
+
+class TestVersionExtraction:
+    """Parsing details that decide whether the comparison means anything."""
+
+    def test_unquoted_version_is_read_as_written(self, repo, tmp_path):
+        """YAML would read an unquoted 1.10 as a float; 1.10 must not become 1.1."""
+        repo.commit("1.0.0")
+        (repo.path / ".github/project.yml").write_text("release:\n  current-version: 1.10\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "--quiet", "-m", "unquoted")
+        sha = _git(repo.path, "rev-parse", "HEAD")
+        result = run_guard(repo, sha)
+        assert result.returncode == 0
+        assert _parse_output(result.stdout)["current-version"] == "1.10"
+
+    def test_reason_is_a_single_line(self, repo):
+        """A multi-line reason would corrupt GITHUB_OUTPUT."""
+        repo.commit("1.0.0")
+        sha = repo.commit("1.0.0", java_versions='["25"]')
+        assert len(run_guard(repo, sha).stdout.strip().split("\n")) == 4

--- a/test/workflow/test_release_guard.py
+++ b/test/workflow/test_release_guard.py
@@ -263,7 +263,7 @@ class TestFailsClosed:
         sha = _git(repo.path, "rev-parse", "HEAD")
         result = run_guard(repo, sha)
         assert result.returncode == 1
-        assert "current-version" in result.stderr
+        assert "does not exist" in result.stderr
 
     def test_unknown_commit_is_an_error(self, repo):
         repo.commit("1.0.0")
@@ -280,6 +280,37 @@ class TestFailsClosed:
         result = run_guard(repo, sha)
         assert result.returncode == 1
         assert "first parent" in result.stderr
+
+    def test_malformed_parent_config_is_an_error_not_a_change(self, repo):
+        """A parent whose config cannot be parsed must not read as "absent"."""
+        (repo.path / ".github").mkdir(exist_ok=True)
+        (repo.path / ".github/project.yml").write_text("release:\n  current-version: [1.0.0\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "--quiet", "-m", "broken config")
+        sha = repo.commit("2.0.0")
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "not valid YAML" in result.stderr
+
+    def test_parent_without_release_block_is_an_error(self, repo):
+        (repo.path / ".github").mkdir(exist_ok=True)
+        (repo.path / ".github/project.yml").write_text("maven-build:\n  java-versions: '[\"21\"]'\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "--quiet", "-m", "no release block")
+        sha = repo.commit("2.0.0")
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "no release block" in result.stderr
+
+    def test_parent_without_current_version_is_an_error(self, repo):
+        (repo.path / ".github").mkdir(exist_ok=True)
+        (repo.path / ".github/project.yml").write_text("release:\n  next-version: 2.0.0-SNAPSHOT\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "--quiet", "-m", "no current-version")
+        sha = repo.commit("2.0.0")
+        result = run_guard(repo, sha)
+        assert result.returncode == 1
+        assert "no release.current-version" in result.stderr
 
     def test_hostile_version_value_is_rejected(self, repo):
         repo.commit("1.0.0")


### PR DESCRIPTION
## Why

`reusable-maven-release.yml` is `on: workflow_call` — it is invoked, never triggered. GitHub evaluates an `on:` block only in the *calling* repo, so the trigger must stay per-caller. **The guard can be centralised, and this is that.**

Every caller filters on `paths: ['.github/project.yml']`. That file also carries `maven-build`, `sonar`, `pages`, `github-automation`, `consumers` and `dependency-propagation`, so an ordinary `maven-build.java-versions` bump matches the filter, merges, and releases. On **2026-07-12** exactly this published an irrevocable `de.cuioss.sheriff.api:*:1.0.0` from API-Sheriff — with `if: github.event.pull_request.merged == true` present and doing nothing to stop it. Merged-ness is the wrong discriminator; version-changed is the right one.

**18 of 19 callers carry the unguarded trigger right now** (only API-Sheriff is dispatch-only, and only because it removed its trigger after the incident). All 19 pin `@15376a19 # v0.17.0` and all 19 are on this repo's `consumers` list, so the next org release closes the exposure everywhere automatically.

## What

A `guard` job now gates the `release` job:

| Invocation | Outcome |
|---|---|
| `workflow_dispatch` | **Proceeds unconditionally**, including re-releasing an unchanged version. The deliberate path must not break. |
| Merged PR, `current-version` unchanged | **Skip**, exit success. A no-op, not a failure. |
| Merged PR, version changed, tag exists | **Skip.** |
| Merged PR, version changed, untagged | Proceed. |
| PR closed unmerged | **Skip**, regardless of version. |

**The already-tagged refusal is load-bearing, not belt-and-braces.** `release:prepare` never writes `current-version` back to `project.yml` — that field is human-maintained — so a revert or re-merge of a version-bump PR genuinely changes the value between parent and merge commit and would pass the version-changed test on its own, at a version already released. Tag matching accepts `1.2.3`, `v1.2.3` and Maven's default `artifactId-1.2.3`.

## Design notes

**Why in the reusable workflow, not an opt-in action.** Callers pin this workflow by SHA, so an in-workflow guard reaches every caller on a mechanical pin bump; an opt-in action needs per-repo wiring — N chances to get it wrong on a mechanism whose failure mode is an irrevocable publish. Protection by default beats protection by remembering. (The logic lives in `.github/actions/release-guard/` so it is lintable, type-checked and unit-tested, but it is invoked unconditionally by the reusable workflow — callers wire up nothing.)

**`fetch-depth: 0` + `fetch-tags: true` are load-bearing.** `actions/checkout` defaults to depth 1, where there is no first parent to compare and no tags to check — the guard would read "unchanged" forever, green for the same reason a deleted test is green. Every undecidable case (unreadable config, unresolvable parent, unusable version string) exits non-zero instead of skipping, so that failure is loud. Blocking a release is visible and recoverable; publishing to Maven Central is not.

**Untrusted input.** `project.yml` is writable by whoever opens the PR being judged. Values reach the script through the environment, never shell interpolation; versions are validated against a strict allowlist and rejected rather than sanitised; `project.yml` is parsed with `yaml.BaseLoader` so an unquoted `1.10` stays `"1.10"` instead of becoming the float `1.1`.

## Caller-visible change

When the guard skips, `release` and everything downstream are skipped, so a caller reading `needs.release.outputs.*` sees empty strings. Callers with a job consuming those outputs should add `if: needs.release.result == 'success'`. (Today those outputs are *always* empty — no `on.workflow_call.outputs` block exists. That is fixed in a separate PR.)

## Verification

22 new tests build **real git repositories** rather than mocking git — the failure this guard exists to prevent is a clone too shallow to have a first parent, which is invisible to a mock. Both controls are covered, including the shallow-clone trap asserted as an *error*, not a skip.

`./pw verify` green; `check-internal-pinning.py` green; ref sweep shows exactly the expected two SHAs.

The empirical negative control (merge a non-release `project.yml` edit in a caller and observe the skip) can only run once this is released and a caller's pin is bumped — it is not something this PR can self-certify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated release gating to ensure releases run only for eligible, merged changes with a new, untagged version.
  - Manual release triggers continue to proceed without additional version checks.
  - Releases now safely stop when required history, configuration, or version information is unavailable.

- **Documentation**
  - Documented release guard behavior, trigger requirements, and caller responsibilities.
  - Updated workflow examples to clarify when releases are evaluated.

- **Tests**
  - Added coverage for version changes, tags, pull request status, repository history, and invalid release conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->