### PR TITLE
fix(release): declare the workflow_call outputs callers actually read

### DIFF
--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -19,6 +19,27 @@ on:
         required: false
         type: boolean
         default: true
+    # Job-level outputs are not visible to a caller — a called workflow must
+    # re-declare them here or `needs.<job>.outputs.*` in the caller evaluates to
+    # the empty string. Without this block a caller building, say, a container
+    # tag from released-version pushes `ghcr.io/cuioss/<repo>:` — malformed, or
+    # worse a silently mislabelled image.
+    outputs:
+      released-version:
+        description: 'The version that was released (release.current-version)'
+        value: ${{ jobs.release.outputs.released-version }}
+      consumers:
+        description: 'Space-separated consumer repositories from project.yml'
+        value: ${{ jobs.release.outputs.consumers }}
+      dep-prop-group-id:
+        description: 'Maven groupId used for dependency propagation'
+        value: ${{ jobs.release.outputs.dep-prop-group-id }}
+      dep-prop-artifact-id:
+        description: 'Maven artifactId used for dependency propagation'
+        value: ${{ jobs.release.outputs.dep-prop-artifact-id }}
+      dep-prop-scope:
+        description: 'Propagation scope: parent or dependency'
+        value: ${{ jobs.release.outputs.dep-prop-scope }}
     secrets:
       RELEASE_APP_ID:
         required: true

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -385,6 +385,49 @@ jobs:
 
 NOTE: Pages deployment uses the cuioss-release-bot app token (generated from `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`), not a separate PAT.
 
+=== Outputs
+
+[cols="1,2"]
+|===
+|Output |Description
+
+|`released-version`
+|The version that was released (`release.current-version`)
+
+|`consumers`
+|Space-separated consumer repositories from `project.yml`
+
+|`dep-prop-group-id`
+|Maven groupId used for dependency propagation
+
+|`dep-prop-artifact-id`
+|Maven artifactId used for dependency propagation
+
+|`dep-prop-scope`
+|Propagation scope: `parent` or `dependency`
+|===
+
+Read them from a downstream job in the calling workflow:
+
+[source,yaml]
+----
+jobs:
+  release:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@<sha>
+    secrets: ...
+
+  publish-image:
+    needs: [release]
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "ghcr.io/cuioss/my-repo:${{ needs.release.outputs.released-version }}"
+----
+
+The `if:` is not optional. The release guard skips the release job for a merge that changed
+no version, and a skipped job's outputs are empty strings — a container tag built from one
+would be `ghcr.io/cuioss/my-repo:`, malformed at best and a mislabelled image at worst.
+
 === Automatic Dependency Propagation
 
 The Maven release workflow can automatically propagate version updates to consumer repositories after release. This is configured in the library repo's `project.yml`:

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -418,15 +418,23 @@ jobs:
 
   publish-image:
     needs: [release]
-    if: needs.release.result == 'success'
+    if: needs.release.outputs.released-version != ''
     runs-on: ubuntu-latest
     steps:
       - run: echo "ghcr.io/cuioss/my-repo:${{ needs.release.outputs.released-version }}"
 ----
 
-The `if:` is not optional. The release guard skips the release job for a merge that changed
-no version, and a skipped job's outputs are empty strings — a container tag built from one
-would be `ghcr.io/cuioss/my-repo:`, malformed at best and a mislabelled image at worst.
+`needs.release` here is the **caller's own** job — the one whose `uses:` points at this
+workflow. Caller jobs cannot reach a called workflow's internal jobs; only the outputs
+declared under `on.workflow_call.outputs` cross that boundary.
+
+The `if:` is not optional, and `needs.release.result == 'success'` is **not** a working
+substitute for it. The release guard skips the release job for a merge that changed no
+version, but the guard job itself ran and succeeded — a run with one successful job and
+several skipped ones is `success`, so a `result`-based condition passes and the downstream
+job runs with every output empty. A container tag built from one would be
+`ghcr.io/cuioss/my-repo:`, malformed at best and a mislabelled image at worst. Test the
+output, not the result.
 
 === Automatic Dependency Propagation
 


### PR DESCRIPTION
## The gap

`reusable-maven-release.yml` declares `released-version`, `consumers`, `dep-prop-group-id`, `dep-prop-artifact-id` and `dep-prop-scope` as **job-level** outputs on its internal `release` job (lines 44–49), but declares **no `on.workflow_call.outputs` block**. A called workflow has to re-declare them there or they are invisible to the caller, so `needs.release.outputs.released-version` evaluates to the empty string in every consumer repo. Verified at `4e8e14d`.

The internal jobs work fine — `wait-for-maven-central` and `propagate-to-consumers` read the job-level outputs from inside the same workflow. Only callers are affected.

## Why it matters concretely

API-Sheriff already carries an in-file workaround in `release.yml`'s `publish-image` job: it re-reads the version from `project.yml` with the pinned `read-project-config` action rather than using a `needs.` expression, with a comment warning that the naive form would push `ghcr.io/cuioss/api-sheriff:` — a malformed reference, or worse a silently mislabelled image. This block lets that workaround be retired and stops the next caller rediscovering the same trap.

## What this adds

The five outputs, plus a docs section showing the caller-side pattern — including the `if: needs.release.result == 'success'` a downstream job needs, since a skipped release job also yields empty outputs.

Shipped separately from the release guard (#224) so each stays reviewable at a glance. The two are independent; either order merges cleanly.

`./pw verify` green; `check-internal-pinning.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw