### PR TITLE
chore: repin executed internal action refs so release-guard resolves

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # This repo's reusable workflows execute this repo's OWN composite actions
+    # by SHA. Those refs are not ordinary dependencies: the release rewrites
+    # them to the release commit before tagging, so that the tagged commit is
+    # itself fully pinned. Dependabot instead resolves them to the newest commit
+    # on main, which is neither the release commit nor the tag — it produced a
+    # third SHA in #223 and would do so again every week.
+    ignore:
+      - dependency-name: "cuioss/cuioss-organization*"
     cooldown:
       default-days: 3
       semver-major-days: 7

--- a/.github/workflows/reusable-maven-build.yml
+++ b/.github/workflows/reusable-maven-build.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
   # Check if only documentation/config files changed (skip build if so).
   # Runs on merge_group too: paths-filter v4 resolves the diff base from the event

--- a/.github/workflows/reusable-maven-integration-tests.yml
+++ b/.github/workflows/reusable-maven-integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
   # Check if only documentation/config files changed (skip tests if so).
   # Runs on merge_group too: paths-filter v4 resolves the diff base from the event
@@ -269,7 +269,7 @@ jobs:
       - name: Assemble test reports
         id: assemble-reports
         if: always()
-        uses: cuioss/cuioss-organization/.github/actions/assemble-test-reports@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/assemble-test-reports@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
         with:
           report-name: ${{ inputs.report-name }}
           reports-folder: ${{ inputs.reports-folder }}

--- a/.github/workflows/reusable-maven-release.yml
+++ b/.github/workflows/reusable-maven-release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Evaluate release guard
         id: guard
-        uses: cuioss/cuioss-organization/.github/actions/release-guard@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/release-guard@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
   release:
     needs: [guard]
@@ -130,7 +130,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
       - name: Set up JDK ${{ steps.config.outputs.java-version || inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/reusable-npm-build.yml
+++ b/.github/workflows/reusable-npm-build.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
   build:
     needs: config

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
       - name: Set up Node.js ${{ steps.config.outputs.npm-node-version || inputs.node-version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/reusable-pyprojectx-verify.yml
+++ b/.github/workflows/reusable-pyprojectx-verify.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Read project.yml configuration
         id: config
-        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@a25cad008cf385954d0eaa77f32751554253c181 # unreleased
 
       - name: Set up Python ${{ steps.config.outputs.pyprojectx-python-version || inputs.python-version }}
         if: ${{ (steps.config.outputs.pyprojectx-python-version || inputs.python-version) != '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,12 @@ All `uses:` references in workflows and actions MUST be SHA-pinned with a versio
 
 - Must be a full 40-char SHA with a version comment: `@15376a1902e0dbe50a43127de9943a28e7f3c8fd # v0.17.0`
 - Never use version tags (`@v0.3.5`) or branch refs (`@main`). A consumer pins us at a SHA; if that commit's own refs are mutable, moving a tag silently changes the code they execute, and OpenSSF Scorecard flags it.
-- **Two internal SHAs coexist after a release, by design** — do not "reconcile" them:
-  - *Executed* composite-action refs inside `.github/workflows/reusable-*.yml` point at the **release commit**, so that the tagged commit is itself fully pinned. A commit cannot contain its own SHA, so it pins its parent — which holds identical action source.
+- **Two internal SHAs coexist, by design** — do not "reconcile" them:
+  - *Executed* composite-action refs inside `.github/workflows/reusable-*.yml` share one SHA. At a release that is the **release commit**, so the tagged commit is itself fully pinned; a commit cannot contain its own SHA, so it pins its parent, which holds identical action source. **Between releases they may sit on an unreleased `main` commit** and carry `# unreleased` instead of a version comment — a newly added action does not exist at the previous release commit, so a ref to it there does not resolve. The release's `--internal-only` pass rewrites them all to the release commit before tagging.
   - *Consumer-facing* refs (docs, `docs/workflow-examples/`, README, commented usage examples) point at the **release tag**, which is what consumers should pin.
 - When adding or modifying an internal `uses:` reference, match the SHA already used by others **of the same kind**.
+- **Adding a new composite action** means repinning *all* executed internal refs together, to a `main` commit that already contains it. Moving only the new one produces a third SHA.
+- Dependabot is configured to `ignore` `cuioss/cuioss-organization*` for exactly this reason: it resolves these refs to the newest commit on `main`, which is neither sanctioned value (see #223).
 
 ### External references (e.g., actions/checkout, actions/setup-java)
 

--- a/test/workflow/test_update_workflow_references.py
+++ b/test/workflow/test_update_workflow_references.py
@@ -342,6 +342,39 @@ jobs:
         assert f"@v{VALID_VERSION}" not in content
         assert "@v0.11.0" not in content
 
+    def test_replaces_a_non_version_comment_rather_than_appending(self, temp_dir):
+        """An `# unreleased` marker must be replaced, not left beside the new one.
+
+        Between releases an internal ref can sit on an unreleased main commit —
+        a newly added action does not exist at the previous release commit, so
+        it has to. Matching only the `# vX.Y.Z` comment shape would leave the
+        marker in place and produce `@sha # v1.2.3 # unreleased`.
+        """
+        old_sha = "2222222222222222222222222222222222222222"
+        reusable_file = self._write_reusable(temp_dir, f"""
+name: Reusable
+on:
+  workflow_call:
+jobs:
+  build:
+    steps:
+      - uses: cuioss/cuioss-organization/.github/actions/release-guard@{old_sha} # unreleased
+""")
+
+        result = run_script(
+            SCRIPT_PATH,
+            "--version", VALID_VERSION,
+            "--sha", self.BASE_SHA,
+            "--internal-only",
+            "--path", str(temp_dir)
+        )
+
+        assert result.returncode == 0
+        content = reusable_file.read_text()
+        assert f"@{self.BASE_SHA} # v{VALID_VERSION}" in content
+        assert "unreleased" not in content
+        assert old_sha not in content
+
     def test_updates_only_reusable_workflows(self, temp_dir):
         """Should not touch non-reusable workflows."""
         self._write_reusable(temp_dir, """

--- a/workflow-scripts/update-workflow-references.py
+++ b/workflow-scripts/update-workflow-references.py
@@ -37,9 +37,15 @@ CUIOSS_REF_PATTERN = re.compile(
 )
 
 # Pattern to match a composite-action reference (the refs a reusable workflow
-# actually executes, as opposed to consumer-facing workflow references)
+# actually executes, as opposed to consumer-facing workflow references).
+#
+# The trailing comment is matched loosely rather than as `# vX.Y.Z`. Between
+# releases these refs may sit on an unreleased main commit — a new action does
+# not exist at the previous release commit, so it has to — and that carries a
+# `# unreleased` marker instead of a version. Matching only the version shape
+# would leave the old comment in place and produce `@sha # v0.18.0 # unreleased`.
 INTERNAL_ACTION_REF_PATTERN = re.compile(
-    r'(uses:\s*cuioss/cuioss-organization/\.github/actions/[^@]+)@[^\s#]+(\s*#\s*v[\d.]+)?'
+    r'(uses:\s*cuioss/cuioss-organization/\.github/actions/[^@]+)@[^\s#]+([ \t]*#[^\n]*)?'
 )
 
 


### PR DESCRIPTION
Two repairs to the internal-pinning invariant, both surfaced while merging #223.

## 1. `release-guard` did not resolve on `main`

Executed composite-action refs pointed at `513eb16`, the v0.17.0 release commit. `.github/actions/release-guard` was added in #224, *after* that commit — so `reusable-maven-release.yml` referenced an action that does not exist at the SHA it pins. The guard job would have failed to find its action.

Nothing executes it today (all 19 callers pin `v0.17.0`, which has no guard at all), and the release's `--internal-only` pass would have repaired it before tagging. But the state is worth fixing rather than carrying: `action-self-test.yml` documents a window where a *changed* action ships stale, and this is a sharper case — a *new* action is inert, not stale.

All eight executed refs now point at `a25cad0`, a `main` commit containing every action they name. Moving only `release-guard` would have produced a third SHA, so they move together and the sweep still shows exactly two:

```
31  15376a19…  consumer-facing + `ref:` lines (the tag)
 8  a25cad00…  executed internal action refs
```

They carry `# unreleased` rather than a version comment, because that is what they are. Verified end-to-end that the release repin converts them cleanly:

```
uses: …/release-guard@1234…5678 # v0.18.0     ← no leftover marker
```

That required `update-workflow-references.py` to match the trailing comment loosely instead of as `# vX.Y.Z`; otherwise the release would have emitted `@sha # v0.18.0 # unreleased`. Covered by a regression test.

## 2. Dependabot will not churn these refs again

#223 rewrote the executed internal refs from `513eb16` to `4e8e14d` — neither the release commit nor the tag, but the post-tag `chore: update workflow references` commit, part of no tag. That is the "reconciliation" `CLAUDE.md` forbids, and it would recur every Monday. Dependabot now ignores `cuioss/cuioss-organization*`.

## Docs

`CLAUDE.md` said executed refs point at the release commit, full stop. That is true *at* a release but not between them, and following it literally is what makes a new action inert. It now states both halves and adds the rule this PR follows: adding a composite action means repinning all executed refs together.

`./pw verify` green; `check-internal-pinning.py` green; sweep shows exactly two SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw