### PR TITLE
docs: align the sweep rule with the repinning rule it verifies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ All `uses:` references in workflows and actions MUST be SHA-pinned with a versio
 
 Before committing changes to workflow files, always verify consistency:
 - `python3 workflow-scripts/check-internal-pinning.py` — fails if any executed `cuioss-organization` ref in `.github/workflows/` is not a 40-char SHA. Also runs on every PR (`./pw verify workflow`) and blocks the release before tagging.
-- `grep -r 'cuioss-organization/' .github/ docs/ --include='*.yml' --include='*.adoc'` — expect at most two SHAs (release commit for executed action refs, tag for consumer-facing refs); anything else is a mistake
+- `grep -r 'cuioss-organization/' .github/ docs/ --include='*.yml' --include='*.adoc'` — expect at most two SHAs: one shared by every executed action ref (the release commit at a release, an unreleased `main` commit between releases) and one for consumer-facing refs (the tag). A third is a mistake, and so is an executed ref that differs from its siblings
 - For any external action you touched, grep to confirm the same SHA is used everywhere
 
 ## Related Repository


### PR DESCRIPTION
Follow-up to #227, which fixed one statement of the internal-pinning rule and missed the other.

`CLAUDE.md` states the rule twice. #227 corrected the **Internal references** bullet — executed action refs share one SHA, which is the release commit *at* a release but an unreleased `main` commit between them — and left the **Verification** section two paragraphs later still asserting the old, unqualified form:

> expect at most two SHAs (release commit for executed action refs, tag for consumer-facing refs)

Anyone running that grep against `main` today sees `a25cad00` for the executed refs, which is not the release commit, and would conclude `main` was broken. It isn't — the wording was.

The rewritten line also states a check the old one left implicit: **executed refs differing from each other is a mistake even when the total is two.** That is precisely the shape Dependabot produced in #223 (it moved 7 of 8) and the shape a newly added composite action produces if repinned alone. Counting distinct SHAs alone does not catch either.

No behaviour change; `./pw verify` and `check-internal-pinning.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw