### PR TITLE
chore: broaden the dependabot ignore that did not hold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,14 @@ updates:
     # on main, which is neither the release commit nor the tag — it produced a
     # third SHA in #223 and would do so again every week.
     ignore:
-      - dependency-name: "cuioss/cuioss-organization*"
+      # Dependabot names these by full path, e.g.
+      # cuioss/cuioss-organization/.github/actions/read-project-config, so the
+      # patterns must cover the path suffix. A bare "cuioss/cuioss-organization*"
+      # did NOT hold — it still opened #228 — so both forms are listed and a new
+      # action needs no new entry.
+      - dependency-name: "cuioss/cuioss-organization"
+      - dependency-name: "cuioss/cuioss-organization/*"
+      - dependency-name: "cuioss/cuioss-organization/**"
     cooldown:
       default-days: 3
       semver-major-days: 7


### PR DESCRIPTION
#227 added `dependency-name: "cuioss/cuioss-organization*"` to stop Dependabot rewriting the executed internal action refs. **It did not work.** Dependabot opened #228 at 09:29, ten minutes *after* #227 merged at 09:19, containing nothing but that churn:

```
- …/read-project-config@a25cad00… # unreleased
+ …/read-project-config@10f8c3dc… # unreleased
```

The PR body shows why — Dependabot names these by full path:

```
Updates `cuioss/cuioss-organization/.github/actions/read-project-config` from a25cad00… to 10f8c3dc…
```

so the pattern has to cover the path suffix. This lists the path-suffixed forms alongside the bare name, rather than enumerating the three actions individually, so adding a composite action needs no new entry here.

**On #228 itself:** its churn is benign, unlike #223. It moves all eight refs together to `10f8c3dc`, a commit that contains every action they name, so the sweep would still show two SHAs. The problem is that Dependabot picking these at all is what produced the genuinely broken state in #223 — a third SHA, on a post-tag commit, with `release-guard` left behind.

**This is not verified yet.** I could not test the matcher without a Dependabot run. Once this merges I will comment `@dependabot recreate` on #228, which regenerates it against the current config; if the ignore holds, Dependabot closes it. Reporting the result rather than assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management rules for the repository’s internal composite actions.
  * Refined ignore patterns to provide more precise coverage across dependency naming levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->