### PR TITLE
chore: spell .github literally in the dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,15 @@ updates:
     # third SHA in #223 and would do so again every week.
     ignore:
       # Dependabot names these by full path, e.g.
-      # cuioss/cuioss-organization/.github/actions/read-project-config, so the
-      # patterns must cover the path suffix. A bare "cuioss/cuioss-organization*"
-      # did NOT hold — it still opened #228 — so both forms are listed and a new
-      # action needs no new entry.
+      # cuioss/cuioss-organization/.github/actions/read-project-config.
+      #
+      # `.github` must appear LITERALLY. Dependabot matches with fnmatch, whose
+      # `*` will not match a path component that begins with a dot, so
+      # "cuioss/cuioss-organization*", ".../*" and ".../**" all failed — each
+      # needs its star to cross `/.github`. Verified: all three were in place
+      # when Dependabot recreated #228 and churned the refs anyway.
       - dependency-name: "cuioss/cuioss-organization"
-      - dependency-name: "cuioss/cuioss-organization/*"
-      - dependency-name: "cuioss/cuioss-organization/**"
+      - dependency-name: "cuioss/cuioss-organization/.github/actions/*"
     cooldown:
       default-days: 3
       semver-major-days: 7


### PR DESCRIPTION
Third attempt at this, and the first with the mechanism actually identified.

## What was tried and observed

| PR | Pattern | Result |
|---|---|---|
| #227 | `cuioss/cuioss-organization*` | Dependabot opened #228 ten minutes later with the churn |
| #230 | added `.../*` and `.../**` | `@dependabot recreate` on #228 — **still churned**, against a main that already contained all three patterns |

So this is not a stale-config problem. The recreated diff targeted `170e14da`, the #230 merge commit, meaning Dependabot read the new config and ignored it anyway.

## Why

Dependabot matches `dependency-name` with fnmatch, and **fnmatch's `*` does not match a path component beginning with a dot.** The dependency is named:

```
cuioss/cuioss-organization/.github/actions/read-project-config
```

Every pattern tried so far requires its star to cross `/.github` — so none of them can match, ever. That is a property of the pattern, not of timing.

Spelling `.github/actions` literally leaves the star matching only `read-project-config`, which has no leading dot:

```yaml
- dependency-name: "cuioss/cuioss-organization"
- dependency-name: "cuioss/cuioss-organization/.github/actions/*"
```

Still generic — a newly added composite action needs no new entry.

## Not claimed as fixed yet

I have been wrong about this twice, so: after merge I will run `@dependabot recreate` on #228 again and report what actually happens. If the ignore holds, Dependabot closes #228 as having nothing to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw