### PR TITLE
fix: scope dependabot cooldown keys to ecosystems that accept them

### DIFF
--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -53,7 +53,10 @@ Synchronize GitHub Actions workflow files from this organization repository to a
 5. **Ensure Dependabot Cooldown**
    - Check if `.github/dependabot.yml` exists in target repo at `{local-path}/.github/dependabot.yml`
    - If exists, check if each `package-ecosystem` entry has a `cooldown` block
-   - For entries missing `cooldown`, add the standard tiered cooldown:
+   - **The cooldown block is ecosystem-specific — it is NOT the same for every entry.**
+     For entries missing `cooldown`, add the variant matching that entry's `package-ecosystem`:
+
+     `maven`, `pip` — tiered cooldown (these ecosystems support the semver keys):
      ```yaml
          cooldown:
            default-days: 3
@@ -61,7 +64,37 @@ Synchronize GitHub Actions workflow files from this organization repository to a
            semver-minor-days: 3
            semver-patch-days: 1
      ```
-   - This delays Dependabot PRs as a supply chain security measure (default: 3d, patch: 1d, minor: 3d, major: 7d)
+
+     `github-actions`, `docker` — `default-days` ONLY:
+     ```yaml
+         cooldown:
+           default-days: 3
+     ```
+   - **Do not add the `semver-*-days` keys to `github-actions` or `docker` for symmetry.**
+     Dependabot rejects them for those ecosystems (`The property
+     '#/updates/0/cooldown/semver-major-days' is not supported for the package
+     ecosystem 'github-actions'`), and a single rejected property invalidates the
+     ENTIRE file — that disables Dependabot version updates repo-wide, not just for
+     the offending entry. This exact mistake broke cuioss-organization, TokenSheriff
+     and API-Sheriff.
+   - For any other ecosystem, verify support in the Dependabot configuration
+     reference before adding the semver keys; when unsure, use `default-days` only.
+   - This delays Dependabot PRs as a supply chain security measure (default: 3d;
+     where tiering applies: patch 1d, minor 3d, major 7d)
+
+5a. **Verify the Dependabot config parses**
+   - Required after ANY edit to a `dependabot.yml`. Dependabot validates the file in a
+     **check-run**, not an Actions run — `gh run list` and a green CI build do NOT cover
+     it, so an invalid file looks like a clean sync until version updates silently stop.
+   - After the commit that changes the file lands, inspect that commit's check-runs:
+     ```
+     gh api repos/cuioss/{repo-name}/commits/{sha}/check-runs \
+       --jq '.check_runs[] | select(.conclusion=="failure") | {name, summary: .output.summary}'
+     ```
+   - Empty output means the config parsed. A failure named `.github/dependabot.yml`
+     reports the offending property path in its summary — fix and re-verify.
+   - The check re-runs whenever the file changes, so the result on the merge commit is
+     the authoritative confirmation.
 
 6. **Display Diffs**
    - For each workflow that differs or is new:

--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -86,14 +86,24 @@ Synchronize GitHub Actions workflow files from this organization repository to a
    - Required after ANY edit to a `dependabot.yml`. Dependabot validates the file in a
      **check-run**, not an Actions run — `gh run list` and a green CI build do NOT cover
      it, so an invalid file looks like a clean sync until version updates silently stop.
-   - After the commit that changes the file lands, inspect that commit's check-runs:
-     ```
+   - Dependabot validates on the **default branch**, so the check-run appears on the
+     merge commit on `main` — not on the PR branch's commits. Verify after merge.
+   - Query the named check-run and read its `status` and `conclusion`:
+     ```bash
      gh api repos/cuioss/{repo-name}/commits/{sha}/check-runs \
-       --jq '.check_runs[] | select(.conclusion=="failure") | {name, summary: .output.summary}'
+       --jq '.check_runs[] | select(.name==".github/dependabot.yml")
+             | {status, conclusion, summary: .output.summary}'
      ```
-   - Empty output means the config parsed. A failure named `.github/dependabot.yml`
-     reports the offending property path in its summary — fix and re-verify.
-   - The check re-runs whenever the file changes, so the result on the merge commit is
+   - Interpret it strictly:
+     - `status: completed` **and** `conclusion: success` — the config parsed. This is the
+       only passing result.
+     - `conclusion: failure` — the `summary` names the offending property path (e.g.
+       `The property '#/updates/0/cooldown/semver-major-days' is not supported for the
+       package ecosystem 'github-actions'`). Fix and re-verify.
+     - **Empty output, or any non-`completed` status, is NOT a pass** — it means the check
+       has not run (or not finished) on that commit. Do not read absence as validity;
+       re-query until the run appears and completes.
+   - The check re-runs whenever the file changes, so its result on the merge commit is
      the authoritative confirmation.
 
 6. **Display Diffs**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,12 @@ updates:
       # when Dependabot recreated #228 and churned the refs anyway.
       - dependency-name: "cuioss/cuioss-organization"
       - dependency-name: "cuioss/cuioss-organization/.github/actions/*"
+    # Only `default-days` here: the `semver-*-days` keys are rejected for the
+    # github-actions ecosystem, and one rejected key invalidates the whole file,
+    # which disables version updates for the entire repo. They stay on `pip`
+    # below, which does support them.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
   # Python (for setup scripts)
   - package-ecosystem: "pip"

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1093,7 +1093,11 @@ Repos on the org-managed merge queue must not also require *branches to be up to
 
 === Recommended: Dependabot Cooldown
 
-For supply chain security, add a tiered cooldown to your `.github/dependabot.yml` to delay updates and allow time for community detection of compromised releases:
+For supply chain security, add a cooldown to your `.github/dependabot.yml` to delay updates and allow time for community detection of compromised releases.
+
+The block is *ecosystem-specific* — it is not the same for every entry.
+
+For `maven` and `pip`, which support per-semver-level tiering:
 
 [source,yaml]
 ----
@@ -1104,7 +1108,26 @@ For supply chain security, add a tiered cooldown to your `.github/dependabot.yml
       semver-patch-days: 1
 ----
 
-Add this block to each ecosystem entry in `dependabot.yml`.
+For `github-actions` and `docker`, `default-days` only:
+
+[source,yaml]
+----
+    cooldown:
+      default-days: 3
+----
+
+Do *not* add the `semver-*-days` keys to `github-actions` or `docker` for symmetry. Dependabot rejects them for those ecosystems, and a single rejected property invalidates the *entire file* — which disables Dependabot version updates repo-wide, not merely for the offending entry.
+
+Dependabot reports this as a *check-run* named `.github/dependabot.yml`, not an Actions run, so a green build does not cover it. After any change to the file, read the check-run on the resulting commit on `main`:
+
+[source,bash]
+----
+gh api repos/cuioss/<repo>/commits/<sha>/check-runs \
+  --jq '.check_runs[] | select(.name==".github/dependabot.yml")
+        | {status, conclusion, summary: .output.summary}'
+----
+
+Only `status: completed` with `conclusion: success` is a pass. Empty output means the check has not run on that commit — not that the file is valid.
 
 == PR Agent Review
 


### PR DESCRIPTION
## The bug

`.github/dependabot.yml` is invalid. Dependabot's config check-run on `b458d0f`:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

A single rejected property invalidates the whole file, so this disabled Dependabot **version updates for the entire repo** — not just the `github-actions` entry. It was invisible in CI because Dependabot validates the config in a *check-run*, not an Actions run; `gh run list` never shows it and the build stayed green.

## Fix 1 — `.github/dependabot.yml`

Dropped the three `semver-*-days` keys from the `github-actions` entry, keeping `default-days: 3`. The `pip` entry (`updates/1`) supports them and is untouched.

## Fix 2 — `.claude/commands/update-github-actions.md` (root cause)

Step 5 "Ensure Dependabot Cooldown" instructed the agent to add the full tiered cooldown block to *every* `package-ecosystem` entry. That instruction is what produced the broken config here, and the same defect in two sibling repos.

Step 5 is now ecosystem-aware:

| ecosystem | cooldown block |
|---|---|
| `maven`, `pip` | `default-days` + the three `semver-*-days` keys |
| `github-actions`, `docker` | `default-days` only |

The reason is stated inline — the semver keys are rejected for those ecosystems and one rejected key disables Dependabot repo-wide — so the next reader does not re-add them for symmetry. Unknown ecosystems default to `default-days` only pending a check of the reference.

New step 5a requires verifying the config after any `dependabot.yml` edit by reading the check-run **by name** on the resulting commit on `main`:

```bash
gh api repos/cuioss/{repo-name}/commits/{sha}/check-runs \
  --jq '.check_runs[] | select(.name==".github/dependabot.yml")
        | {status, conclusion, summary: .output.summary}'
```

Only `status: completed` with `conclusion: success` is a pass. Empty output or a pending status is explicitly *not* a pass — it means the check has not run on that commit.

## Fix 3 — `docs/Workflows.adoc` (added after review)

The "Recommended: Dependabot Cooldown" section carried the same instruction that caused the bug ("Add this block to each ecosystem entry", next to the full tiered block). It is the operator-facing copy, so leaving it would recreate the invalid config in consumer repos even with the command fixed. Now split into the two ecosystem variants with the reason stated, plus the check-run verification.

## Follow-ups needed elsewhere (NOT in this PR)

Both carry the same defect on their `github-actions` **and** `docker` entries and need their own PRs:

- [ ] `cuioss/TokenSheriff`
- [ ] `cuioss/API-Sheriff`

## Verification

- `.github/dependabot.yml` parses locally; `github-actions` → `{default-days: 3}`, `pip` → tiered block unchanged.
- Swept the repo for `semver-major-days`; remaining hits are only the maven/pip block, the `pip` entry, and quoted error text.
- Dependabot validates on the **default branch** — confirmed there is no `.github/dependabot.yml` check-run on this PR's branch commits at all. The check-run on the merge commit is the real confirmation, and will be verified after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw