### PR TITLE
fix: make the cooldown rule repair existing wrong blocks, not just missing ones

### DIFF
--- a/.claude/commands/update-github-actions.md
+++ b/.claude/commands/update-github-actions.md
@@ -52,11 +52,10 @@ Synchronize GitHub Actions workflow files from this organization repository to a
 
 5. **Ensure Dependabot Cooldown**
    - Check if `.github/dependabot.yml` exists in target repo at `{local-path}/.github/dependabot.yml`
-   - If exists, check if each `package-ecosystem` entry has a `cooldown` block
    - **The cooldown block is ecosystem-specific — it is NOT the same for every entry.**
-     For entries missing `cooldown`, add the variant matching that entry's `package-ecosystem`:
+     The correct block per `package-ecosystem`:
 
-     `maven`, `pip` — tiered cooldown (these ecosystems support the semver keys):
+     `maven`, `pip`, `npm` — tiered cooldown (these ecosystems support the semver keys):
      ```yaml
          cooldown:
            default-days: 3
@@ -70,13 +69,23 @@ Synchronize GitHub Actions workflow files from this organization repository to a
          cooldown:
            default-days: 3
      ```
+   - Walk **every** `package-ecosystem` entry and bring it to the block above. Two
+     distinct cases, and you must handle both:
+     - **Entry has no `cooldown`** — add the variant for its ecosystem.
+     - **Entry already has a `cooldown`** — do NOT assume it is correct. If it is a
+       `github-actions` or `docker` entry carrying any `semver-*-days` key, **delete
+       those keys**, keeping `default-days`. An existing block is the *likely* defect,
+       not evidence of a healthy config: earlier revisions of this command instructed
+       adding the tiered block everywhere, so repos synced under it carry a wrong
+       cooldown rather than a missing one.
    - **Do not add the `semver-*-days` keys to `github-actions` or `docker` for symmetry.**
      Dependabot rejects them for those ecosystems (`The property
      '#/updates/0/cooldown/semver-major-days' is not supported for the package
      ecosystem 'github-actions'`), and a single rejected property invalidates the
      ENTIRE file — that disables Dependabot version updates repo-wide, not just for
      the offending entry. This exact mistake broke cuioss-organization, TokenSheriff
-     and API-Sheriff.
+     and API-Sheriff; TokenSheriff ran with version updates silently disabled for over
+     five weeks because nothing re-reports the error until the file changes again.
    - For any other ecosystem, verify support in the Dependabot configuration
      reference before adding the semver keys; when unsure, use `default-days` only.
    - This delays Dependabot PRs as a supply chain security measure (default: 3d;

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1097,7 +1097,7 @@ For supply chain security, add a cooldown to your `.github/dependabot.yml` to de
 
 The block is *ecosystem-specific* — it is not the same for every entry.
 
-For `maven` and `pip`, which support per-semver-level tiering:
+For `maven`, `pip` and `npm`, which support per-semver-level tiering:
 
 [source,yaml]
 ----
@@ -1118,11 +1118,23 @@ For `github-actions` and `docker`, `default-days` only:
 
 Do *not* add the `semver-*-days` keys to `github-actions` or `docker` for symmetry. Dependabot rejects them for those ecosystems, and a single rejected property invalidates the *entire file* — which disables Dependabot version updates repo-wide, not merely for the offending entry.
 
+If an entry *already* has a `cooldown` block, do not assume it is correct — an existing block is the likely defect rather than evidence of a healthy config, because earlier guidance told operators to add the tiered block to every entry. Audit each `github-actions` and `docker` entry and delete any `semver-*-days` keys it carries, keeping `default-days`.
+
 Dependabot reports this as a *check-run* named `.github/dependabot.yml`, not an Actions run, so a green build does not cover it. After any change to the file, read the check-run on the resulting commit on `main`:
 
 [source,bash]
 ----
 gh api repos/cuioss/<repo>/commits/<sha>/check-runs \
+  --jq '.check_runs[] | select(.name==".github/dependabot.yml")
+        | {status, conclusion, summary: .output.summary}'
+----
+
+To audit a repo you have *not* just changed, read the check-run on the commit that last touched the file — the check only re-runs when `dependabot.yml` changes, so a broken config goes on reporting nothing on every later commit:
+
+[source,bash]
+----
+SHA=$(gh api "repos/cuioss/<repo>/commits?path=.github/dependabot.yml&per_page=1" --jq '.[0].sha')
+gh api "repos/cuioss/<repo>/commits/$SHA/check-runs" \
   --jq '.check_runs[] | select(.name==".github/dependabot.yml")
         | {status, conclusion, summary: .output.summary}'
 ----


### PR DESCRIPTION
Follow-up to #233, which closed only half the hole.

## The gap

Step 5 as merged reads *"For entries missing `cooldown`, add the variant…"*. But the already-broken repos are **not** missing a cooldown — they have a wrong one, written by the earlier revision of this very command. As merged, the command prevents new breakage and walks straight past every existing victim.

Step 5 now walks **every** `package-ecosystem` entry and handles both cases:

- entry has no `cooldown` → add the variant for its ecosystem
- entry already has one → do not assume it is correct; strip `semver-*-days` from `github-actions` / `docker`, keeping `default-days`

with the reason stated: an existing block is the *likely* defect rather than evidence of health, because repos synced under the old guidance carry a wrong one.

## npm supports the semver keys

TokenSheriff's check-run rejects only `updates/1` (github-actions) and `updates/2` (docker); its `maven` and `npm` entries pass. So `npm` joins `maven` and `pip` in the tiered list.

## Auditing a repo you have not just changed

`docs/Workflows.adoc` gets both corrections above, plus this — the check only re-runs when `dependabot.yml` changes, so a broken config reports nothing on every later commit and looks clean:

```bash
SHA=$(gh api "repos/cuioss/<repo>/commits?path=.github/dependabot.yml&per_page=1" --jq '.[0].sha')
gh api "repos/cuioss/<repo>/commits/$SHA/check-runs" \
  --jq '.check_runs[] | select(.name==".github/dependabot.yml")
        | {status, conclusion, summary: .output.summary}'
```

That is exactly why TokenSheriff went unnoticed: broken on 2026-06-28, still broken today, silent on every commit since.

## Related

- cuioss/TokenSheriff#621 — the actual repair there
- API-Sheriff is being handled separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw