### PR TITLE
fix(pr-agent): narrow empty-review guard to the runner's reviewed actions

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -296,8 +296,12 @@ jobs:
       #
       # SCOPE — every run that should produce review output, and only those:
       #
-      #   - pull_request runs, when auto-review is on (auto-review: false produces none by
-      #     definition).
+      #   - pull_request runs whose action is one the runner actually reviews, when auto-review
+      #     is on (auto-review: false produces none by definition). The allow-list in the if:
+      #     below mirrors GITHUB_ACTION_CONFIG.PR_ACTIONS — opened, reopened, ready_for_review,
+      #     review_requested — which is the exact set run_action() branches on before it reaches
+      #     PRReviewer.run(). Selecting on the EVENT alone asserted a precondition the runner's
+      #     own config denies for every other action.
       #   - issue_comment runs whose command is /review. This path matters MORE than the
       #     automatic one, not less: there is deliberately no `synchronize` trigger, so /review
       #     is the ONLY way to re-review after a push, and plan-marshall's automatic-review skill
@@ -309,14 +313,42 @@ jobs:
       # would fail a gate keyed on the event alone. /improve and /describe write their own output
       # keys ('improve' / 'describe'), not 'review'.
       #
+      # EXCLUDED — runs that legitimately produce no review output, and why each is out of the
+      # gate's reach:
+      #
+      #   (a) synchronize reaching handle_push_trigger while that trigger is off. run_action()
+      #       defaults it to False and logs `Skipping action`, so no tool runs and the empty
+      #       output is correct.
+      #   (b) synchronize with the trigger ON but the push disqualified by one of run_action()'s
+      #       four early returns: before == after (unchanged SHA), an after SHA that is the
+      #       merge commit, a Bot sender, or no push_commands configured. Each of the four
+      #       returns before any tool runs.
+      #   (c) a pull request with no files — PRReviewer.run() returns early.
+      #   (d) an empty diff after filtering — _prepare_prediction() yields no prediction.
+      #
+      # (a) and (b) are excluded by the if: below because on those actions the gate's precondition
+      # is UNEVALUABLE, not merely unmet: the runner emits no output, exit code, or marker that
+      # distinguishes a legitimate skip from a total model failure. github_action_output(…, 'review')
+      # is reached only after a successful prediction, so every skip path — legitimate or failed —
+      # leaves the output empty and the two look identical from here. (c) and (d) sit on retained
+      # actions and stay inside the gated population as a known, accepted residual.
+      #
+      # Downgrading this gate to a ::warning is PROHIBITED. Its exit 1 is the only signal that
+      # separates "reviewed, found nothing" from "never reviewed"; as a warning it separates
+      # nothing, and the false green the gate exists to prevent comes back.
+      #
       # Verified against upstream v0.39.0 before narrowing: github_action_output() is a no-op
       # unless github_action_config.enable_output is truthy, and github_action_runner.py:63
       # defaults it to True and sets it BEFORE the event branch — so the output is written on the
       # comment path exactly as on the pull_request path.
       - name: Verify the reviewer actually produced a review
         if: >-
-          ${{ (github.event_name == 'pull_request' && inputs.auto-review)
-              || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/review')) }}
+          ${{ (github.event_name == 'pull_request'
+               && inputs.auto-review
+               && contains(fromJSON('["opened", "reopened", "ready_for_review", "review_requested"]'),
+                           github.event.action))
+              || (github.event_name == 'issue_comment'
+                  && startsWith(github.event.comment.body, '/review')) }}
         env:
           REVIEW_OUTPUT: ${{ steps.review.outputs.review }}
           GH_TOKEN: ${{ steps.review-token.outputs.token }}

--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -79,8 +79,8 @@ permissions:
 #   - Comment runs are keyed per COMMENT: each is a distinct, explicit human request (/review is
 #     not /ask), so they must not collapse into one group. Dropping one because another arrived
 #     is never right.
-#   - pull_request runs are keyed per PR: opened/reopened/ready_for_review are redundant
-#     notifications about the same state, so grouping them is correct.
+#   - pull_request runs are keyed per PR: every reviewed action is a redundant notification
+#     about the same state, so grouping them is correct.
 #   - cancel-in-progress stays FALSE, matching the org-wide policy in docs/Workflows.adoc
 #     ("we intentionally do not use workflow-level concurrency with cancel-in-progress").
 #
@@ -302,6 +302,21 @@ jobs:
       #     review_requested — which is the exact set run_action() branches on before it reaches
       #     PRReviewer.run(). Selecting on the EVENT alone asserted a precondition the runner's
       #     own config denies for every other action.
+      #
+      #     CONTRACT — that mirror only holds while pr_actions stays at its default.
+      #     GITHUB_ACTION_CONFIG.PR_ACTIONS is CONFIGURABLE: a repo-local .pr_agent.toml, or the
+      #     org file in cuioss/pr-agent-settings, can override it, and neither is visible from
+      #     here. Narrow it and this gate asserts on actions the runner no longer reviews, failing
+      #     them closed; widen it and the gate silently stops covering the added action. So do NOT
+      #     set github_action_config.pr_actions anywhere without changing this list AND the caller
+      #     template's `types:` in the same edit.
+      #
+      #     test_pr_agent_review_guard.py pins the half of that contract this repository can see:
+      #     the list is exactly REVIEWED_ACTIONS, the documented caller template subscribes to
+      #     every one of them, and nothing here overrides pr_actions. The other half — that
+      #     pr-agent-settings does not override it either — is NOT machine-checked from this
+      #     repository, and is stated here so a future editor knows it is a convention rather
+      #     than an enforced invariant.
       #   - issue_comment runs whose command is /review. This path matters MORE than the
       #     automatic one, not less: there is deliberately no `synchronize` trigger, so /review
       #     is the ONLY way to re-review after a push, and plan-marshall's automatic-review skill

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1159,7 +1159,7 @@ name: PR Agent Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, review_requested]
   issue_comment:
     types: [created]
 
@@ -1283,7 +1283,16 @@ structured output is the only oracle that holds however that repository is confi
 
 The check covers automatic `pull_request` runs whose action is one the runner actually reviews —
 `opened`, `reopened`, `ready_for_review` and `review_requested`, the runner's own allow-list —
-plus `/review` comments. It is scoped by command rather than by event, because `/ask` and `/help`
+plus `/review` comments. Those four are exactly the caller template's `pull_request` `types:`
+above, and that alignment is a contract rather than a coincidence: PR-Agent's
+`github_action_config.pr_actions` is configurable from a repo-local `.pr_agent.toml` or from the
+org file in `cuioss/pr-agent-settings`, so narrowing it makes the check assert on actions the
+runner no longer reviews, and widening it makes the check silently stop covering the added
+action. Changing `pr_actions` therefore means changing the guard's allow-list and the caller
+template in the same edit. The regression suite pins the part this repository can observe — the
+allow-list is exactly that set, the template subscribes to all of it, and nothing here overrides
+`pr_actions`; that `pr-agent-settings` does not override it either is a convention, not an
+enforced invariant. It is scoped by command rather than by event, because `/ask` and `/help`
 write no review output at all. The `/review` path is the one consumers depend on for a
 re-review — including automation that posts the command programmatically — so leaving it
 unverified would have reproduced the same false green on the path that matters most.
@@ -1304,8 +1313,8 @@ The concurrency group is keyed on the *trigger*, not the pull request:
 
 * Comment-triggered runs group per comment id. Each slash-command is a distinct explicit
 request, so two of them must never collapse into one group.
-* `pull_request` runs group per pull request number, since `opened` / `reopened` /
-`ready_for_review` are redundant notifications about the same state.
+* `pull_request` runs group per pull request number, since every reviewed action is a redundant
+notification about the same state.
 
 This shape is load-bearing, not incidental. Concurrency is evaluated at workflow level, *before*
 the job's `if:` guard, so a group keyed on the pull request alone lets any comment — including

--- a/docs/Workflows.adoc
+++ b/docs/Workflows.adoc
@@ -1281,11 +1281,21 @@ publish decision — never a published comment. Whether a clean review publishes
 persistent and updated in place, so a stale one would satisfy a naive check forever. The
 structured output is the only oracle that holds however that repository is configured.
 
-The check covers both paths that produce review output: automatic `pull_request` runs, and
-`/review` comments. It is scoped by command rather than by event, because `/ask` and `/help`
+The check covers automatic `pull_request` runs whose action is one the runner actually reviews —
+`opened`, `reopened`, `ready_for_review` and `review_requested`, the runner's own allow-list —
+plus `/review` comments. It is scoped by command rather than by event, because `/ask` and `/help`
 write no review output at all. The `/review` path is the one consumers depend on for a
 re-review — including automation that posts the command programmatically — so leaving it
 unverified would have reproduced the same false green on the path that matters most.
+
+Every other `pull_request` action is deliberately outside the check. The runner returns before
+any tool runs on them, so an empty output is the correct outcome rather than a failure — and the
+check could not cover them in any case, because the runner emits no output, exit code or marker
+distinguishing a legitimate skip from a total model failure, which leaves its precondition
+unevaluable there rather than merely unmet. Two narrower populations — a pull request with no
+files, and an empty diff after filtering — arise on reviewed actions and so remain inside the
+check as an accepted residual. The workflow's own `EXCLUDED` comment block carries the full
+enumeration.
 
 === Concurrency
 

--- a/test/workflow/test_pr_agent_review_guard.py
+++ b/test/workflow/test_pr_agent_review_guard.py
@@ -10,10 +10,14 @@ scope, the fail-closed `exit 1`, and the in-file enumeration of the populations 
 legitimately empty and therefore excluded.
 """
 
+import json
+import re
+
 import pytest
 import yaml
 
 WORKFLOW_PATH = ".github/workflows/reusable-pr-agent-review.yml"
+DOCS_PATH = "docs/Workflows.adoc"
 GUARD_STEP_NAME = "Verify the reviewer actually produced a review"
 REVIEWED_ACTIONS = ("opened", "reopened", "ready_for_review", "review_requested")
 
@@ -79,10 +83,68 @@ def guard_comment_block(workflow_text):
     return "\n".join(reversed(block))
 
 
+@pytest.fixture
+def docs_text(project_root):
+    """Raw Workflows.adoc source, including the caller template's YAML block."""
+    return (project_root / DOCS_PATH).read_text(encoding="utf-8")
+
+
+def _guard_allow_list(condition):
+    """The guard's action allow-list, parsed out of its `fromJSON('[…]')` literal."""
+    match = re.search(r"fromJSON\('(\[.*?\])'\)", condition, re.DOTALL)
+    assert match is not None, "the guard's action allow-list is no longer a fromJSON array"
+    return json.loads(match.group(1))
+
+
 @pytest.mark.parametrize("action", REVIEWED_ACTIONS)
 def test_if_allow_lists_every_reviewed_action(guard_step, action):
     """Each action in the runner's PR_ACTIONS default stays inside the guard's scope."""
     assert f'"{action}"' in guard_step["if"]
+
+
+def test_if_allow_lists_exactly_the_reviewed_actions(guard_step):
+    """The allow-list is that set and nothing more.
+
+    Its sibling above tests membership, which cannot fail when the list GROWS: adding
+    `synchronize` to the workflow would keep every one of those cases green while silently
+    re-broadening the gate over the exact population this change excludes on purpose. Set
+    equality is what makes an added action fail here rather than pass unnoticed.
+    """
+    assert set(_guard_allow_list(guard_step["if"])) == set(REVIEWED_ACTIONS)
+
+
+def test_caller_template_subscribes_to_every_reviewed_action(docs_text):
+    """The documented caller template triggers on every action the guard admits.
+
+    An action in the allow-list that no caller ever sends is dead scope, and the reverse — a
+    subscribed action outside the allow-list — is an ungated run. Both directions are pinned
+    here because the two lists live in different files and drift silently otherwise.
+
+    Anchored on the PR-Agent template's own `name:`, because Workflows.adoc documents several
+    caller templates and an unanchored search binds to whichever `pull_request:` block appears
+    first — a different workflow's, whose `types:` has nothing to do with this guard.
+    """
+    template = re.search(
+        r"^name: PR Agent Review$.*?^  pull_request:\n    types: \[(.*?)\]$",
+        docs_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert template is not None, "the PR Agent Review caller template was not found"
+    subscribed = {entry.strip() for entry in template.group(1).split(",")}
+    assert subscribed == set(REVIEWED_ACTIONS)
+
+
+def test_no_pr_actions_override_in_this_repository(workflow_text, docs_text):
+    """Nothing here overrides `github_action_config.pr_actions`.
+
+    The guard's allow-list is only correct while that setting stays at its default, and an
+    override is the one local edit that would falsify it without touching either list. Prose
+    mentions of the key are expected — the assertion targets an ASSIGNMENT, so documenting the
+    contract does not trip the guard that enforces it.
+    """
+    assignment = re.compile(r"github_action_config\.pr_actions\s*[:=]")
+    for label, text in (("workflow", workflow_text), ("docs", docs_text)):
+        assert not assignment.search(text), f"{label} assigns github_action_config.pr_actions"
 
 
 def test_if_discriminates_on_the_event_action(guard_step):

--- a/test/workflow/test_pr_agent_review_guard.py
+++ b/test/workflow/test_pr_agent_review_guard.py
@@ -1,0 +1,138 @@
+"""Regression tests for the PR-Agent empty-review guard's trigger scope.
+
+The guard in `.github/workflows/reusable-pr-agent-review.yml` fails the job when the
+reviewer produced no structured output. That assertion is only sound on runs the runner
+is contractually obliged to review, so the guard's `if:` mirrors PR-Agent's own
+`GITHUB_ACTION_CONFIG.PR_ACTIONS` allow-list rather than selecting on the event alone.
+
+These tests pin the three things that must not be silently undone: the narrowed trigger
+scope, the fail-closed `exit 1`, and the in-file enumeration of the populations that are
+legitimately empty and therefore excluded.
+"""
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = ".github/workflows/reusable-pr-agent-review.yml"
+GUARD_STEP_NAME = "Verify the reviewer actually produced a review"
+REVIEWED_ACTIONS = ("opened", "reopened", "ready_for_review", "review_requested")
+
+# Every population that legitimately produces no review output, keyed by the group letter
+# the workflow's own EXCLUDED comment block uses. Asserted as one parametrized set so that
+# dropping any single group — including (a), the population that motivates the change —
+# fails the suite rather than passing silently.
+EXCLUDED_POPULATIONS = {
+    "a_synchronize_with_push_trigger_off": (
+        "synchronize",
+        "handle_push_trigger",
+        "Skipping action",
+    ),
+    "b_run_action_early_returns": (
+        "before == after",
+        "unchanged SHA",
+        "merge commit",
+        "Bot",
+        "push_commands",
+    ),
+    "c_pull_request_with_no_files": ("no files",),
+    "d_empty_diff_after_filtering": ("empty diff",),
+}
+
+
+@pytest.fixture
+def workflow_text(project_root):
+    """Raw workflow source, including the comments `yaml.safe_load` discards."""
+    return (project_root / WORKFLOW_PATH).read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def guard_step(workflow_text):
+    """The parsed guard step, located by name across every job in the workflow."""
+    workflow = yaml.safe_load(workflow_text)
+    for job in workflow["jobs"].values():
+        for step in job.get("steps", []):
+            if step.get("name") == GUARD_STEP_NAME:
+                return step
+    raise AssertionError(f"guard step not found: {GUARD_STEP_NAME}")
+
+
+@pytest.fixture
+def guard_comment_block(workflow_text):
+    """The contiguous `#` comment block immediately above the guard step.
+
+    Scoped to that block rather than the whole file so a token surviving somewhere
+    unrelated cannot make the enumeration assertions pass vacuously.
+    """
+    lines = workflow_text.splitlines()
+    anchor = next(
+        (index for index, line in enumerate(lines) if line.strip() == f"- name: {GUARD_STEP_NAME}"),
+        None,
+    )
+    assert anchor is not None, f"guard step not found: {GUARD_STEP_NAME}"
+
+    block = []
+    cursor = anchor - 1
+    while cursor >= 0 and lines[cursor].strip().startswith("#"):
+        block.append(lines[cursor])
+        cursor -= 1
+    assert block, "the guard step carries no explanatory comment block"
+    return "\n".join(reversed(block))
+
+
+@pytest.mark.parametrize("action", REVIEWED_ACTIONS)
+def test_if_allow_lists_every_reviewed_action(guard_step, action):
+    """Each action in the runner's PR_ACTIONS default stays inside the guard's scope."""
+    assert f'"{action}"' in guard_step["if"]
+
+
+def test_if_discriminates_on_the_event_action(guard_step):
+    """The allow-list is applied to `github.event.action`, the field the runner branches on."""
+    condition = guard_step["if"]
+    assert "github.event.action" in condition
+    assert "contains(" in condition
+    assert "fromJSON" in condition
+
+
+def test_if_admits_no_bare_pull_request_arm(guard_step):
+    """The specific regression: a pull_request arm with no action check re-broadens the guard.
+
+    Every top-level arm that tests for the pull_request event must also constrain the
+    action, otherwise the guard again asserts a precondition the runner's config denies.
+    """
+    arms = guard_step["if"].split("||")
+    pull_request_arms = [arm for arm in arms if "'pull_request'" in arm]
+
+    assert pull_request_arms, "the pull_request arm disappeared from the guard"
+    for arm in pull_request_arms:
+        assert "github.event.action" in arm, f"unconstrained pull_request arm: {arm.strip()}"
+
+
+def test_if_retains_the_review_comment_arm(guard_step):
+    """The /review path is untouched by the narrowing — it is the only re-review door."""
+    condition = guard_step["if"]
+    assert "github.event_name == 'issue_comment'" in condition
+    assert "startsWith(github.event.comment.body, '/review')" in condition
+
+
+def test_run_still_fails_closed_on_an_empty_review(guard_step):
+    """An attempted-but-empty review on a retained path still fails the job."""
+    body = guard_step["run"]
+    assert '-z "$REVIEW_OUTPUT"' in body
+    assert "exit 1" in body
+
+
+def test_run_carries_no_warning_downgrade(guard_step):
+    """Negative control.
+
+    `::warning` is the prohibited remedy, not a quieter equivalent: the non-zero exit is
+    the only signal separating "reviewed, found nothing" from "never reviewed". A future
+    "make it less noisy" edit must fail here rather than pass silently.
+    """
+    assert "::warning" not in guard_step["run"]
+
+
+@pytest.mark.parametrize(("group", "tokens"), sorted(EXCLUDED_POPULATIONS.items()))
+def test_comment_block_enumerates_every_excluded_population(guard_comment_block, group, tokens):
+    """The reasoning for each excluded population stays in the file, so no reader re-broadens it."""
+    missing = [token for token in tokens if token not in guard_comment_block]
+    assert not missing, f"excluded population {group} lost token(s): {missing}"


### PR DESCRIPTION
## The defect

`reusable-pr-agent-review.yml` gates its review job on a non-empty
`steps.review.outputs.review` and fails the job when that output is absent. The gate's `if:`
selected on the **event** — `github.event_name == 'pull_request'` — while the runner's
obligation to write that output is conditioned on the **action** being a member of
`GITHUB_ACTION_CONFIG.PR_ACTIONS` (`opened`, `reopened`, `ready_for_review`,
`review_requested`).

For every other `pull_request` action the runner returns before any tool runs, so the output
is legitimately absent. The gate therefore asserted a precondition the runner's own
configuration denies, and its `exit 1` would misread a correct skip as a failed review.

## Latent, not live — and why this lands first

**No consumer is failing today.** No caller subscribes to an action outside the allow-list, so
the gate never evaluates on one. This is a pre-emptive narrowing.

It has to land first because the next step of this work adds `synchronize` to the callers'
`types:` — `synchronize` is the only door to `handle_push_trigger`, so enabling the push
trigger necessarily means subscribing to it. The moment that happens, every legitimately-empty
push arms the false failure across every consumer at once. Narrowing the gate before the
trigger is enabled is what keeps that from being a fan-out incident.

## The change

The `pull_request` arm now mirrors the runner's own allow-list via
`contains(fromJSON('["opened", "reopened", "ready_for_review", "review_requested"]'),
github.event.action)`. The `issue_comment` + `/review` arm is unchanged.

The step body is **untouched**: `exit 1` on an empty `REVIEW_OUTPUT` stays byte-for-byte and is
never downgraded to a `::warning`. That non-zero exit is the only signal separating "reviewed,
found nothing" from "never reviewed"; as a warning it separates nothing.

No `inputs`, `secrets` or `outputs` surface changes.

## Blast radius

The workflow is consumed by roughly **21 repositories**. Consumers pick this up on their normal
workflow-SHA pin bump — **no consumer action is required**, because the reusable workflow's
interface is unchanged. Behaviour changes only in that the guard stops firing on actions the
runner never reviews.

## Accepted residuals

Both are enumerated in-file, in the workflow's own `EXCLUDED` comment block, so a later reader
has the argument rather than the conclusion:

- **R1 — the discriminator is the action allow-list, not observable runner state.** The runner
  exposes no state that separates a legitimate skip from a total model failure:
  `github_action_output(…, 'review')` is reached only after a successful prediction, so every
  skip path leaves the output empty and the two look identical from the workflow. On the
  excluded actions the gate's precondition is *unevaluable*, not merely unmet. Deriving the
  scope from `github.event.action` — the field `run_action()` itself branches on — is the
  closest faithful discriminator the runner's contract permits. No push-reason field (`before`,
  `after`, `merge_commit_sha`, `sender.type`) is re-derived in YAML.
- **R3 — two legitimately-empty populations stay inside the gate.** A pull request with no
  files, and an empty diff after filtering, both arise on *reviewed* actions and so remain
  gated. They are reachable today and represent a small live false-failure surface that this
  change does not close; closing it would require runner state that does not exist.

## Verification

- `./pw verify` green end to end — 440 passed, mypy and ruff clean.
- New regression test `test/workflow/test_pr_agent_review_guard.py` (13 cases) pins the
  narrowed scope, the fail-closed exit, and the in-file enumeration.
- The negative control was confirmed to discriminate: against a mutant that downgrades `exit 1`
  to a `::warning` it fails, against a mutant that restores the bare `pull_request` arm it
  fails, and deleting any single excluded-population group from the comment block fails its own
  parametrized case.
- `docs/Workflows.adoc` § PR Agent Review → Verification updated in lockstep; the workflow's
  existing "no `synchronize` trigger" statement and the doc's "no automatic re-review on push"
  statement are both deliberately left intact — this is step (1) and does not enable the
  trigger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review verification for supported automatic-review actions.
  * Preserved verification for `/review` comment requests.
  * Prevented false failures for actions that intentionally produce no review output.

* **Documentation**
  * Clarified covered and excluded pull request actions.

* **Tests**
  * Added regression coverage for review triggers, empty results, fail-closed behavior, and excluded actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->