### PR TITLE
fix(repo-settings): derive repository scope from the org, not a hand list

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,15 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@937fbcf44d34d826b3bcd66d49d7a7d32030f39a # v0.18.0
+    permissions:
+      contents: write
+      pull-requests: write

--- a/repo-settings/README.adoc
+++ b/repo-settings/README.adoc
@@ -84,7 +84,7 @@ gh auth login
 
 == Usage
 
-1. Edit `config.json` - add repositories, adjust settings
+1. Edit `config.json` to adjust settings
 2. Run the script:
 +
 [source,bash]
@@ -94,18 +94,25 @@ gh auth login
 
 == Configuration
 
-=== Adding Repositories
+=== Repository Scope
+
+An empty `repositories` list means every active repository in the organization, enumerated from the API at run time. Archived repositories are excluded because they reject setting writes, and forks are excluded because they are not ours to configure.
+
+Discovery is the default because a hand-maintained list drifts as repositories are added, and a repository absent from it is silently never configured. That is how `plan-marshall` and `cuioss-organization` came to sit outside the Dependabot auto-merge rollout: batch mode iterated an empty list and reported success over it.
+
+Name repositories explicitly only to narrow a run to a subset:
 
 [source,json]
 ----
 {
   "repositories": [
-    "OAuth-Sheriff",
-    "cui-java-parent",
-    "my-new-repo"
+    "cui-java-tools",
+    "cui-jsf-components"
   ]
 }
 ----
+
+A run that resolves to no repositories at all is an error, not a no-op.
 
 === Customizing Settings
 

--- a/repo-settings/config.json
+++ b/repo-settings/config.json
@@ -37,5 +37,6 @@
       "description": "Eligible for automated merge by the cuioss dependabot sweeper"
     }
   ],
+  "$repositories_comment": "Empty means every active non-fork repository in the organization, resolved from the API at run time. Name repositories explicitly only to narrow a run; a hand-maintained list drifts silently as repositories are added.",
   "repositories": []
 }

--- a/repo-settings/setup-repo-settings.py
+++ b/repo-settings/setup-repo-settings.py
@@ -4,7 +4,7 @@
 Requires: gh cli (https://cli.github.com/)
 
 Usage:
-    ./setup-repo-settings.py                          # Process all repos in config.json
+    ./setup-repo-settings.py                          # Process config.json repos, or the whole org if that list is empty
     ./setup-repo-settings.py --repo cui-java-tools --diff   # Show diff for single repo
     ./setup-repo-settings.py --repo cui-java-tools --apply  # Apply settings to single repo
 """
@@ -69,6 +69,37 @@ def load_config(config_path: Path) -> dict:
     """Load configuration from JSON file."""
     with open(config_path) as f:
         return json.load(f)
+
+
+def discover_org_repos(org: str) -> list[str]:
+    """Enumerate the organization's active repositories.
+
+    Archived repos reject setting writes, and forks are not ours to configure,
+    so both are excluded. The `--limit` is deliberately far above the current
+    repo count: gh silently truncates at the limit, and a truncated enumeration
+    would reintroduce the very coverage gap this discovery exists to close.
+    """
+    result = run_gh(
+        [
+            "repo", "list", org,
+            "--limit", "1000",
+            "--no-archived",
+            "--source",
+            "--json", "name",
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        log_error(f"Could not enumerate repositories for {org}: {result.stderr.strip()}")
+        sys.exit(1)
+
+    try:
+        repos = [entry["name"] for entry in json.loads(result.stdout)]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        log_error(f"Could not parse repository listing for {org}: {exc}")
+        sys.exit(1)
+
+    return sorted(repos)
 
 
 def check_sidebar_sections(org: str, repo: str) -> dict:
@@ -499,7 +530,7 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s                              Process all repos in config.json
+  %(prog)s                              Process config.json repos, or the whole org if that list is empty
   %(prog)s --repo cui-java-tools --diff Show diff for single repo
   %(prog)s --repo cui-java-tools --apply Apply settings to single repo
   %(prog)s custom-config.json           Use custom config file
@@ -513,7 +544,7 @@ Examples:
     parser.add_argument(
         "--repo",
         metavar="NAME",
-        help="Process a single repository instead of all in config",
+        help="Process a single repository instead of the full batch",
     )
     parser.add_argument(
         "--diff",
@@ -576,9 +607,27 @@ def main() -> None:
     log_info(f"Organization: {org}")
     log_info(f"Config file: {config_path}")
 
+    # An explicit list in config.json narrows the run; an empty one means "the
+    # whole organization", resolved from the API rather than hand-maintained.
+    # A hand-maintained list is what let plan-marshall and cuioss-organization
+    # sit outside the dependabot auto-merge rollout unnoticed: batch mode
+    # iterated an empty list and still reported success.
+    repositories = config["repositories"]
+    if repositories:
+        log_info(f"Repositories: {len(repositories)} from config")
+    else:
+        repositories = discover_org_repos(org)
+        log_info(f"Repositories: {len(repositories)} discovered (active, non-fork)")
+
+    # Reporting success over an empty set is indistinguishable from reporting it
+    # over a configured one, so an empty set is an error rather than a no-op.
+    if not repositories:
+        log_error(f"No repositories to process for organization {org}")
+        sys.exit(1)
+
     # Process each repository
     failed_repos: list[str] = []
-    for repo in config["repositories"]:
+    for repo in repositories:
         apply_repo_settings(org, repo, config)
         apply_labels(org, repo, config)
         apply_security_settings(org, repo, config)

--- a/test/repo-admin/test_setup_repo_settings.py
+++ b/test/repo-admin/test_setup_repo_settings.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Add parent to path to access conftest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from conftest import PROJECT_ROOT, run_script
@@ -442,3 +444,121 @@ class TestLabelVerification:
             patch.object(mod, "check_sidebar_warnings"),
         ):
             assert mod.verify_settings("cuioss", "test-repo", config) is False
+
+
+class TestRepositoryDiscovery:
+    """Test organization-wide repository discovery.
+
+    A hand-maintained repository list drifts as repositories are added, and a
+    repository absent from it is silently never configured -- which is how
+    plan-marshall and cuioss-organization sat outside the Dependabot
+    auto-merge rollout while batch mode reported success over an empty list.
+    """
+
+    def test_discovers_active_non_fork_repos(self):
+        mod = _load_module()
+        listing = MagicMock(
+            returncode=0,
+            stdout='[{"name":"cui-http"},{"name":"API-Sheriff"}]',
+        )
+        with patch.object(mod, "run_gh", return_value=listing):
+            assert mod.discover_org_repos("cuioss") == ["API-Sheriff", "cui-http"]
+
+    def test_excludes_archived_and_forks(self):
+        """Archived repos reject setting writes; forks are not ours to configure."""
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout='[{"name":"cui-http"}]')
+        with patch.object(mod, "run_gh", return_value=listing) as gh:
+            mod.discover_org_repos("cuioss")
+        args = gh.call_args[0][0]
+        assert "--no-archived" in args
+        assert "--source" in args
+
+    def test_limit_exceeds_org_size(self):
+        """gh truncates silently at --limit, which would reopen the coverage gap."""
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout="[]")
+        with patch.object(mod, "run_gh", return_value=listing) as gh:
+            mod.discover_org_repos("cuioss")
+        args = gh.call_args[0][0]
+        assert int(args[args.index("--limit") + 1]) >= 1000
+
+    def test_exits_when_listing_fails(self):
+        """Unenumerable is not the same as empty -- do not silently process nothing."""
+        mod = _load_module()
+        failure = MagicMock(returncode=1, stdout="", stderr="boom")
+        with patch.object(mod, "run_gh", return_value=failure):
+            with pytest.raises(SystemExit) as exc:
+                mod.discover_org_repos("cuioss")
+        assert exc.value.code != 0
+
+    def test_exits_on_malformed_listing(self):
+        mod = _load_module()
+        listing = MagicMock(returncode=0, stdout="not json", stderr="")
+        with patch.object(mod, "run_gh", return_value=listing):
+            with pytest.raises(SystemExit) as exc:
+                mod.discover_org_repos("cuioss")
+        assert exc.value.code != 0
+
+
+class TestBatchScope:
+    """Test which repositories a batch run actually processes.
+
+    Exercised through main() rather than through the helpers, because the
+    defect being closed was in the wiring: discover_org_repos can be correct
+    while batch mode still iterates the empty config list.
+    """
+
+    def _run_main(self, mod, temp_dir, repositories, discovered):
+        config = temp_dir / "config.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "organization": "cuioss",
+                    "repositories": repositories,
+                    "features": {},
+                    "merge": {},
+                    "security": {},
+                }
+            )
+        )
+        processed = []
+        with (
+            patch.object(sys, "argv", ["setup-repo-settings.py", str(config)]),
+            patch.object(mod, "check_dependencies"),
+            patch.object(mod, "discover_org_repos", return_value=discovered) as discover,
+            patch.object(mod, "apply_repo_settings", side_effect=lambda o, r, c: processed.append(r)),
+            patch.object(mod, "apply_labels"),
+            patch.object(mod, "apply_security_settings"),
+            patch.object(mod, "verify_settings", return_value=True),
+        ):
+            try:
+                mod.main()
+                exit_code = 0
+            except SystemExit as exc:
+                exit_code = exc.code or 0
+        return processed, discover, exit_code
+
+    def test_empty_config_list_triggers_discovery(self, temp_dir):
+        """The shipped config carries an empty list, so this is the normal path."""
+        mod = _load_module()
+        processed, discover, exit_code = self._run_main(mod, temp_dir, [], ["alpha", "beta"])
+        discover.assert_called_once_with("cuioss")
+        assert processed == ["alpha", "beta"]
+        assert exit_code == 0
+
+    def test_explicit_config_list_is_not_overridden(self, temp_dir):
+        """An explicit list narrows the run; it must not be widened to the org."""
+        mod = _load_module()
+        processed, discover, exit_code = self._run_main(mod, temp_dir, ["only-this-one"], ["alpha", "beta"])
+        discover.assert_not_called()
+        assert processed == ["only-this-one"]
+        assert exit_code == 0
+
+    def test_empty_resolved_scope_is_an_error(self, temp_dir):
+        """Reporting success over zero repositories is indistinguishable from
+        reporting it over the whole org -- the exact defect this closes."""
+        mod = _load_module()
+        processed, _, exit_code = self._run_main(mod, temp_dir, [], [])
+        assert processed == []
+        assert exit_code != 0


### PR DESCRIPTION
## Problem

Eight green Dependabot PRs had accumulated in `cuioss/plan-marshall` and none had ever merged automatically. The cause was not CI, and not the merge queue: that repository never received the caller workflow rolled out with #215, so nothing applied the `automerge` label and the sweeper never saw the PRs.

An audit of all 27 non-archived `cuioss` repositories found 20 with a `.github/dependabot.yml`. Eighteen carry the caller workflow and the `automerge` label. The two that do not are **`plan-marshall`** and **`cuioss-organization` itself**.

The reason both could be missed, and stay missed, is in this repository:

```json
"repositories": []
```

Batch mode iterates that list, so it processed nothing — and then printed `All repository settings applied and verified!`. A vacuous success is indistinguishable from a real one, so the rollout had to be hand-enumerated per repo and nothing could detect what the hand missed. `--diff` against `plan-marshall` confirms it was never processed at all: `dependabot_alerts`, `secret_scanning`, and `secret_scanning_push_protection` are all unset there.

## Change

**Scope is now derived from the organization.** An empty `repositories` list means every active repository, enumerated from the API at run time:

- Archived repositories are excluded — they reject setting writes.
- Forks are excluded — they are not ours to configure.
- `--limit` is set far above the current repo count, because `gh` truncates silently at the limit and a truncated enumeration would reintroduce exactly the coverage gap this closes.

A named list still narrows a run to a subset. A scope that resolves to **zero** repositories is now an error rather than a no-op, so the vacuous-success path is closed in both directions — an unenumerable org fails loudly instead of passing as "nothing to do".

**Adds the auto-merge caller workflow to this repository**, closing the second of the two gaps. It is byte-identical to the one in the eighteen covered repositories and pinned to the same `v0.18.0` commit.

## Out-of-band prerequisite

The `automerge` label has been provisioned in both `plan-marshall` and `cuioss-organization` (`0e8a16`, matching `config.json`). This is deliberately not automated in the workflow: the reusable job holds only `pull-requests: write` and cannot create labels, so a missing label fails the step loudly rather than merging nothing quietly.

## Verification

`./pw verify` green — 435 tests, mypy and ruff clean.

Nine tests added across two classes. `TestRepositoryDiscovery` covers the helper: sorted output, the archived/fork exclusions asserted on the constructed argv, the `--limit` floor, and non-zero exit on both a failed and a malformed listing. `TestBatchScope` drives `main()` rather than the helper, because the defect was in the *wiring* — `discover_org_repos` can be perfectly correct while batch mode still iterates the empty config list.

Negative control run: reverting only the `if repositories:` branch in `main()` fails `test_empty_config_list_triggers_discovery` and nothing else, confirming the test binds to the wiring rather than passing vacuously.

## Blast radius

Running `./setup-repo-settings.py` with no arguments now acts on all 27 active repositories instead of silently doing nothing. That is the script's documented purpose, and no operation it performs is destructive — but it is a real behavior change for anyone who ran it expecting the previous no-op.

## Follow-up

`cuioss/plan-marshall#1110` adds the caller workflow there. The eight stranded PRs predate both changes and receive no `pull_request` event from them, so they are being landed by hand; four are major bumps that `allowed-update-types: minor,patch` excludes by design regardless.
