### PR TITLE
feat(pr-agent): gate /improve behind the pr-agent-improve label

### DIFF
--- a/.github/workflows/reusable-pr-agent-review.yml
+++ b/.github/workflows/reusable-pr-agent-review.yml
@@ -31,9 +31,10 @@ on:
         default: false
       auto-improve:
         description: >-
-          Run /improve automatically. Off by default: committable suggestions are already
-          CodeRabbit's job, so enabling this duplicates findings and roughly doubles the
-          token cost per pull request.
+          Force /improve on for every pull request in this repository. Off by default,
+          because the ordinary opt-in is per pull request: label it pr-agent-improve and
+          this workflow picks that up on its own. Set this input only when a repository
+          wants inline suggestions unconditionally.
         required: false
         type: boolean
         default: false
@@ -252,9 +253,27 @@ jobs:
           # The three tool toggles are the one deliberate exception to central configuration:
           # they are caller inputs, so a single repository can opt into /improve without
           # editing the org-wide file. Everything else comes from cuioss/pr-agent-settings.
+          #
+          # auto_improve additionally honours a per-PULL-REQUEST opt-in: the pr-agent-improve
+          # label. The label is read HERE rather than in each caller, mirroring the way
+          # skip-bot-review is read in the job guard above — so no adopting repository has to
+          # touch its caller workflow for the gate to work, and a maintainer can ask for inline
+          # suggestions on one pull request without turning them on for the whole repository.
+          # The input remains the always-on switch; the label is the per-pull-request one.
+          #
+          # On issue_comment runs github.event.pull_request is absent, so the label term
+          # contributes nothing. That is correct rather than a gap: those runs execute the
+          # command the commenter actually typed, and auto_improve governs only the automatic
+          # pull_request path.
+          #
+          # The fail-closed gate below is deliberately NOT extended to /improve. That gate's
+          # oracle is steps.review.outputs.review, and /improve writes the separate 'improve'
+          # output key — so a gate keyed on the review output would fail every improve-only run
+          # while proving nothing about the suggestions themselves. Guarding /improve requires
+          # its own oracle, which is a separate change, not a widening of this one.
           github_action_config.auto_review: ${{ inputs.auto-review }}
           github_action_config.auto_describe: ${{ inputs.auto-describe }}
-          github_action_config.auto_improve: ${{ inputs.auto-improve }}
+          github_action_config.auto_improve: ${{ inputs.auto-improve || contains(github.event.pull_request.labels.*.name, 'pr-agent-improve') }}
 
       # FAIL-CLOSED GATE — the reviewer step above CANNOT be trusted to report its own failure.
       # PR-Agent's action runner catches its own exceptions, logs them at WARNING/ERROR, and


### PR DESCRIPTION
## Intent

Gate `/improve` behind a `pr-agent-improve` label so the reviewer can post inline suggestions at
all, without turning it on for every pull request in every repository.

This is deliverable 6 of PLAN-PR-022 (`a-generic-charter-cannot-see-a-language-specific-defect`),
whose host-side work landed in `cuioss/plan-marshall#1130`.

## Why this is smaller than it sounds

The `/improve` wiring already exists here. `auto-improve` is a declared `workflow_call` input, the
`github_action_config.auto_improve` wiring is present, and `/improve` is already in the
`issue_comment` guard. The only missing piece was the **label gate**, so this change is one
expression rather than a new mechanism.

The default stays **off**. A caller's `auto-improve` input still forces it on for a whole
repository; this adds a per-pull-request opt-in that mirrors the existing `skip-bot-review` idiom.
This widens the surface deliberately, not silently — `/improve` is the one path that writes into
the diff.

## Why it was worth doing

Across a 58-PR sweep the org's third reviewer posted **zero** inline comments and **zero** review
submissions on all 32 pull requests where it participated; 28 of those carried the bare
"No major issues detected" table. One cause is that `/improve` — the tool that actually publishes
inline — has never been reachable.

## Two upstream facts that shaped this

Both were assumptions until checked against the pinned image at `v0.39.0`, and both were wrong in
the direction that would have wasted the work:

- **There is no `pr_reviewer.inline_code_comments`.** It looked like a cheaper alternative that
  would make the label gate unnecessary — make `/review` itself publish inline. The key does not
  exist at this tag, and `pr_reviewer.py` publishes only via `publish_comment` /
  `publish_persistent_comment`. Inline publishing is an `/improve` capability, so this gate is the
  correct mechanism rather than the expensive one.
- **`restricted_mode = true` does not gate `/improve`.** It withholds exactly one capability,
  `push_code`, whose confirmed consumer is the changelog tool. `/improve` publishes through the PR
  review API (`pull-requests: write`), not `contents: write`. Had it been gated, this deliverable
  would have needed re-scoping to grant elevated permissions.

Stated coverage limit, carried honestly: `is_supported` call sites were not exhaustively
enumerated across the upstream repo, and only the GitHub provider was inspected — the result does
not transfer by proof to GitLab, Bitbucket or Azure DevOps.

## Merge order

This PR is the **second** of three coupled changes:

1. `cuioss/pr-agent-settings#14` — adds the central `[pr_code_suggestions]` block
2. **this PR** — label-gates `/improve` behind `pr-agent-improve`
3. `cuioss/API-Sheriff` + `cuioss/TokenSheriff` — roll the generated Java packs out

Merging this before (1) would gate a tool whose config block does not yet exist.

## Base-branch note

Branched from `origin/main` rather than the unmerged `fix/pr-agent-empty-review-guard-scope`
(PR #235), after confirming the two diffs are disjoint: #235 touches only the fail-closed gate
region, this touches the input block and env wiring. They merge cleanly in either order.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling automatic improvements on individual pull requests using the `pr-agent-improve` label.
  * Retained the repository-wide option for always-on automatic improvements.

* **Documentation**
  * Clarified how the automatic improvement settings work, including their behavior for comment-triggered reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->